### PR TITLE
refactor: Abbreviate conda build badge text

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,4 +1,4 @@
-name: Python Package using Conda
+name: Conda Build
 
 on: [push]
 

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ el1xr_opt
    :target: https://pypi.org/project/el1xr_opt/
    :alt: Python version
 
-.. image:: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/python-package-conda.yml/badge.svg
-   :target: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/python-package-conda.yml
+.. image:: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/conda-build.yml/badge.svg
+   :target: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/conda-build.yml
    :alt: Test passing
    :width: 150
 


### PR DESCRIPTION
The badge for the conda build workflow was too long, causing layout issues. This commit shortens the badge text by:

1. Renaming the workflow file from `python-package-conda.yml` to `conda-build.yml`.
2. Changing the workflow `name` to "Conda Build".
3. Updating the `README.rst` to point to the new workflow file.

This results in a more concise badge that fits better with the other badges in the README.