### PR TITLE
refactor: Update badges and rename workflow

### DIFF
--- a/.github/workflows/gitHub-test.yml
+++ b/.github/workflows/gitHub-test.yml
@@ -1,4 +1,4 @@
-name: Python Package using Conda
+name: gitHub-test
 
 on: [push]
 

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ el1xr_opt
    :target: https://pypi.org/project/el1xr_opt/
    :alt: Python version
 
-.. image:: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/python-package-conda.yml/badge.svg
-   :target: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/python-package-conda.yml
+.. image:: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/gitHub-test.yml/badge.svg
+   :target: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/gitHub-test.yml
    :alt: Test passing
 
 .. image:: https://readthedocs.org/projects/el1xr-opt/badge/?version=latest
@@ -27,8 +27,8 @@ el1xr_opt
    :target: https://app.codacy.com/gh/EL1XR-dev/el1xr_opt/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade
    :alt: Codacy Badge
 
-.. image:: https://img.shields.io/pypi/dm/el1xr_opt.svg
-   :target: https://pypi.org/project/el1xr_opt/
+.. image:: https://img.shields.io/pepy/dt/el1xr_opt.svg
+   :target: https://pepy.tech/project/el1xr_opt
    :alt: Downloads
 
 **Electricity for Low-carbon Integration and eXchange of Resources (EL1XR)**


### PR DESCRIPTION
This commit addresses several issues with the badges in the README:

1. Renames the conda build workflow to `gitHub-test.yml` and updates the `name` to `gitHub-test` to shorten the badge text.
2. Updates the corresponding badge in `README.rst` to point to the new workflow.
3. Replaces the rate-limited PyPI downloads badge with a more reliable one from `pepy.tech` via `shields.io`.

These changes improve the appearance and reliability of the status badges.