### PR TITLE
docs: Update project structure in user guide

### DIFF
--- a/docs/rst/user-guide/project-structure.rst
+++ b/docs/rst/user-guide/project-structure.rst
@@ -7,17 +7,24 @@ This project follows a `src/` layout:
 
 ::
 
-    VY4E-OptModel/
+    el1xr_opt/
     ├─ pyproject.toml
     ├─ src/
-    │  └─ vy4e_optmodel/
+    │  └─ el1xr_opt/
     │     ├─ __init__.py
-    │     ├─ data/
-    │     ├─ model/
-    │     ├─ optimization/
-    │     ├─ scenarios/
-    │     ├─ solvers/
-    │     └─ results/
+    │     ├─ __main__.py
+    │     ├─ el1xr_Main.py
+    │     ├─ Grid1/
+    │     ├─ Home1/
+    │     └─ Modules/
+    │        ├─ __init__.py
+    │        ├─ oM_InputData.py
+    │        ├─ oM_LoadCase.py
+    │        ├─ oM_ModelFormulation.py
+    │        ├─ oM_OutputData.py
+    │        ├─ oM_ProblemSolving.py
+    │        ├─ oM_Sequence.py
+    │        └─ oM_SolverSetup.py
     └─ docs/
 
-Imports resolve via the package name (e.g., ``vy4e_optmodel.model``).
+Imports resolve via the package name (e.g., ``el1xr_opt.Modules``).


### PR DESCRIPTION
The project structure documented in `docs/rst/user-guide/project-structure.rst` was outdated. This commit updates the documentation to reflect the current `el1xr_opt` project structure.

The changes include:
- Updating the root directory name from `VY4E-OptModel` to `el1xr_opt`.
- Reflecting the correct file and directory structure under `src/el1xr_opt/`.
- Updating the example import to `el1xr_opt.Modules`.