### PR TITLE
Docs: Update data and I/O documentation

### DIFF
--- a/docs/rst/user-guide/data-and-io.rst
+++ b/docs/rst/user-guide/data-and-io.rst
@@ -3,14 +3,15 @@ Data & I/O
 
 Data formats
 ------------
-- CSV/Parquet tables with multi-index (period, scenario, stage)
-- YAML/JSON for settings and metadata
+The model is data-driven, with all inputs defined in a collection of CSV files
+located in a dedicated case directory. These files define the model's sets (e.g.,
+periods, technologies, nodes) and parameters (e.g., costs, capacities, efficiencies).
 
 Loaders
 -------
-.. autofunction:: vy4e_optmodel.data.load_case
+.. autofunction:: el1xr_opt.Modules.oM_LoadCase.load_case
 
 Writers
 -------
-.. automodule:: vy4e_optmodel.results
-    :members:
+.. automodule:: el1xr_opt.Modules.oM_OutputData
+    :members: saving_rawdata, saving_results


### PR DESCRIPTION
The `docs/rst/user-guide/data-and-io.rst` file contained outdated information that referred to a different project (`vy4e_optmodel`). This change updates the documentation to accurately reflect the data formats, loaders, and writers used in the `el1xr_opt` project.

Specifically, the following changes were made:
- The "Data formats" section was updated to indicate that the model uses a collection of CSV files for data input.
- The `autofunction` and `automodule` directives were corrected to point to the appropriate modules and functions in the `el1xr_opt` package:
    - Loader: `el1xr_opt.Modules.oM_LoadCase.load_case`
    - Writers: `el1xr_opt.Modules.oM_OutputData`, with the `saving_rawdata` and `saving_results` functions explicitly mentioned.