### PR TITLE
docs: Add documentation for model sets

### DIFF
--- a/docs/rst/user-guide/examples.rst
+++ b/docs/rst/user-guide/examples.rst
@@ -1,11 +1,37 @@
 Examples
 ========
 
-Example notebooks / scripts
----------------------------
-- ``examples/case_small``: minimal case
-- ``examples/case_bess``: battery operation & sizing
-- ``examples/case_h2``: hydrogen subsystem
+The framework includes pre-configured example cases that demonstrate how to structure input data for different energy system scales and configurations. These cases can be found in the ``src/el1xr_opt/`` directory and can be run using the main script.
 
-.. note::
-    Link these once added to the repository.
+Grid-Scale System: ``Grid1``
+-----------------------------
+
+The ``Grid1`` case represents a simplified, grid-scale hybrid energy system. It is designed to model the interactions between electricity and hydrogen networks, including various generation, storage, and demand technologies.
+
+**Key Features:**
+
+*   **Integrated Networks**: Includes data for both electricity and hydrogen grids (``oM_Data_ElectricityNetwork_Grid1.csv``, ``oM_Data_HydrogenNetwork_Grid1.csv``).
+*   **Multiple Technologies**: Models a mix of generation assets, such as conventional power plants, renewables, and electrolyzers.
+*   **Demand Profiles**: Contains sample data for electricity and hydrogen demand (``oM_Data_ElectricityDemand_Grid1.csv``, ``oM_Data_HydrogenDemand_Grid1.csv``).
+*   **Operational Constraints**: The model is configured to consider operational details like generator ramping limits and minimum uptime/downtime, as specified in ``oM_Data_Option_Grid1.csv``.
+
+This case is useful for users interested in transmission-level analysis, sector coupling, and large-scale renewable integration.
+
+Residential Microgrid: ``Home1``
+--------------------------------
+
+The ``Home1`` case models a small-scale residential microgrid or a single "energy-prosumer" home. It is suitable for analyzing behind-the-meter assets and local energy optimization.
+
+**Key Features:**
+
+*   **Local Assets**: Focuses on typical residential technologies like rooftop solar PV, battery storage, and a home charger for an electric vehicle.
+*   **Retail Tariffs**: Incorporates data for electricity retail prices and tariffs (``oM_Data_ElectricityRetail_Home1.csv``, ``oM_Data_Tariff_Home1.csv``), which are key drivers for residential optimization.
+*   **Simplified Network**: Assumes a single-node or a very simple local network structure.
+*   **Operational Logic**: Like the grid-scale case, it uses an options file (``oM_Data_Option_Home1.csv``) to define the active model constraints.
+
+This case serves as a good starting point for users focused on distributed energy resources (DERs), demand response, and home energy management systems.
+
+Running the Examples
+--------------------
+
+To run an example, you typically need to point the main execution script (e.g., ``el1xr_Main.py``) to the desired case directory. This is usually done by modifying a configuration file or a command-line argument that specifies the ``CaseName`` (e.g., "Grid1" or "Home1").

--- a/docs/rst/user-guide/model-sets.rst
+++ b/docs/rst/user-guide/model-sets.rst
@@ -1,0 +1,70 @@
+Model Sets
+==========
+
+The optimization model is built upon a series of indexed sets that define its dimensions, including time, space, and technology. These sets are used by Pyomo to create variables and constraints efficiently. Understanding these sets is crucial for interpreting the model's structure and preparing input data.
+
+The core sets are defined in the ``model`` object and are accessible throughout the formulation scripts (e.g., in ``oM_ModelFormulation.py``).
+
+Temporal Hierarchy
+------------------
+
+The model uses a nested temporal structure to represent time, from long-term planning periods down to hourly operational timesteps.
+
+*   ``model.p``: **Periods**. The highest level, typically representing years in an investment planning horizon.
+*   ``model.sc``: **Scenarios**. Represents different operational conditions within a period, such as typical weather weeks or stress-case scenarios.
+*   ``model.n``: **Timesteps / Load Levels**. The finest temporal resolution, usually representing hours or sub-hourly intervals within a scenario.
+
+These are often used in combination:
+
+*   ``model.ps``: A combined set of ``(period, scenario)``.
+*   ``model.psn``: A combined set of ``(period, scenario, timestep)``, representing every unique time point in the model.
+
+Spatial Representation
+----------------------
+
+The spatial dimension defines the physical layout of the energy system.
+
+*   ``model.nd``: **Nodes**. Represents distinct locations or buses in the energy network. All assets (generators, demands, storage) are assigned to a node.
+*   ``model.ela``: **Electricity Arcs**. Defines the connections (transmission lines) in the electricity grid, represented as ``(node_from, node_to, circuit_id)``.
+*   ``model.hpa``: **Hydrogen Arcs**. Defines the connections (pipelines) in the hydrogen network.
+
+Technology and Asset Sets
+-------------------------
+
+The model uses a rich set of indices to differentiate between various types of technologies and assets. There is a clear separation between the electricity and hydrogen systems.
+
+General Technology Subsets
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+*   **Electricity Generation (`eg`)**:
+    *   ``model.egt``: Dispatchable generators that can be committed (turned on/off), like gas turbines.
+    *   ``model.egs``: Electricity storage units, like batteries.
+    *   ``model.egnr``: Non-renewable generators.
+    *   ``model.egv``: Variable renewable energy sources (VRES), like solar and wind.
+
+*   **Hydrogen Production (`hg`)**:
+    *   ``model.hgt``: Dispatchable hydrogen producers.
+    *   ``model.hgs``: Hydrogen storage units, like salt caverns or tanks.
+
+*   **Energy Conversion**:
+    *   ``model.e2h``: Technologies that convert **electricity to hydrogen** (e.g., electrolyzers). This is a subset of ``hg``.
+    *   ``model.h2e``: Technologies that convert **hydrogen to electricity** (e.g., fuel cells). This is a subset of ``eg``.
+
+Demand and Retail
+~~~~~~~~~~~~~~~~~
+
+*   ``model.ed``: Electricity demands.
+*   ``model.hd``: Hydrogen demands.
+*   ``model.er``: Electricity retail markets (points of common coupling for buying/selling from a wholesale market).
+*   ``model.hr``: Hydrogen retail markets.
+
+Node-to-Technology Mappings
+---------------------------
+
+The model uses mapping sets to link specific assets to their locations in the network. For example:
+
+*   ``model.n2eg``: Maps which electricity generators exist at which nodes.
+*   ``model.n2hg``: Maps which hydrogen producers exist at which nodes.
+*   ``model.n2ed``: Maps electricity demands to nodes.
+
+These sets are fundamental for building the energy balance constraints at each node. By combining temporal, spatial, and technological sets, the model can create highly specific variables, such as ``vEleTotalOutput[p,sc,n,eg]``, which represents the electricity output of generator ``eg`` at a specific time ``(p,sc,n)``.


### PR DESCRIPTION
Creates a new page in the user guide, `model-sets.rst`, to document the core Pyomo sets used in the optimization model.

This documentation details the temporal, spatial, and technological sets, providing essential context for users and developers to understand the model's structure and data requirements.