### PR TITLE
Docs: Align objective function equations with code

### DIFF
--- a/docs/rst/concepts/objective-and-costs.rst
+++ b/docs/rst/concepts/objective-and-costs.rst
@@ -17,13 +17,14 @@ Total system cost in [Cost-unit] («``eTotalSCost``»)
 
 And the total cost is the sum of all operational costs, discounted to present value («``eTotalTCost``»):
 
-:math:`\text{vTotalSCost} = \sum_{p \in P, sc \in SC} \text{DiscountFactor}_{p} \times`
-:math:`\text{vTotalEleMCost}_{p,sc} + \text{vTotalHydMCost}_{p,sc} +`
-:math:`\text{vTotalEleGCost}_{p,sc} + \text{vTotalHydGCost}_{p,sc} +`
-:math:`\text{vTotalECost}_{p,sc} +`
-:math:`\text{vTotalEleCCost}_{p,sc} + \text{vTotalHydCCost}_{p,sc} +`
-:math:`\text{vTotalEleRCost}_{p,sc} + \text{vTotalHydRCost}_{p,sc} +`
-:math:`\text{vTotalElePeakCost}_{p,sc}`
+.. math::
+   \text{vTotalSCost} = \sum_{p \in P, sc \in SC, n \in N} \text{pDiscountFactor}_{p} \times (
+   & \text{vTotalEleMCost}_{p,sc,n} + \text{vTotalHydMCost}_{p,sc,n} + \\
+   & \text{vTotalEleGCost}_{p,sc,n} + \text{vTotalHydGCost}_{p,sc,n} + \\
+   & \text{vTotalECost}_{p,sc,n} + \\
+   & \text{vTotalEleCCost}_{p,sc,n} + \text{vTotalHydCCost}_{p,sc,n} + \\
+   & \text{vTotalEleRCost}_{p,sc,n} + \text{vTotalHydRCost}_{p,sc,n}) + \\
+   & \sum_{p \in P, sc \in SC} \text{vTotalElePeakCost}_{p,sc}
 
 Where:
 
@@ -46,18 +47,27 @@ The total cost is broken down into several components, each represented by a spe
     *   Cost components: ``vTotalEleTradeCost``, ``vTotalHydTradeCost``
     *   Revenue components: ``vTotalEleTradeProfit``, ``vTotalHydTradeProfit``
 
-    #.  **Electricity Purchase** (``vTotalEleTradeCost``): The cost incurred from purchasing electricity from the market.
+    #.  **Electricity Purchase** (``vTotalEleTradeCost``): The cost incurred from purchasing electricity from the market. This cost is defined by the constraint ``eTotalEleTradeCost`` and includes variable energy costs, taxes, and other fees.
 
-        :math:`\text{vTotalEleTradeCost} = \sum_{t \in T, n \in N_{EleTrade}}`
-        :math:`\text{pEleTradeCost}_{t,n} \times \text{vEleTrade}_{t,n}`
+        .. math::
+           \text{vTotalEleTradeCost}_{p,sc,n} = \sum_{er \in ER} \text{pDuration}_{p,sc,n} \times ((\text{pVarEnergyCost}_{er,p,sc,n} \times \text{pEleRetBuyingRatio}_{er} + \\
+           \text{pEleRetelcertifikat}_{er} \times \text{factor1} + \text{pEleRetpaslag}_{er} \times \text{factor1}) \times (1 + \text{pEleRetmoms}_{er} \times \text{factor1}) + \\
+           \text{pEleRetnetavgift}_{er} \times \text{factor1}) \times \text{vEleBuy}_{p,sc,n,er}
 
-    #.  **Electricity Sales** (``vTotalEleTradeProfit``): The revenue generated from selling electricity to the market.
+    #.  **Electricity Sales** (``vTotalEleTradeProfit``): The revenue generated from selling electricity to the market. This is defined by the constraint ``eTotalEleTradeProfit``.
 
-        :math:`\text{vTotalEleTradeProfit} = \sum_{t \in T, n \in N_{EleTrade}}`
-        :math:`\text{pEleTradeProfit}_{t,n} \times \text{vEleTrade}_{t,n}`
+        .. math::
+           \text{vTotalEleTradeProfit}_{p,sc,n} = \sum_{er \in ER} \text{pDuration}_{p,sc,n} \times (\text{pVarEnergyPrice}_{er,p,sc,n} \times \text{pEleRetSellingRatio}_{er} \times \text{vEleSell}_{p,sc,n,er})
 
-    #.  **Hydrogen Purchase (`vTotalHydTradeCost`)**: The cost incurred from purchasing hydrogen from the market.
-    #.  **Hydrogen Sales (`vTotalHydTradeProfit`)**: The revenue generated from selling hydrogen to the market.
+    #.  **Hydrogen Purchase** (``vTotalHydTradeCost``): The cost incurred from purchasing hydrogen from the market, as defined by ``eTotalHydTradeCost``.
+
+        .. math::
+           \text{vTotalHydTradeCost}_{p,sc,n} = \sum_{hr \in HR} \text{pDuration}_{p,sc,n} \times (\text{pVarEnergyCost}_{hr,p,sc,n} \times \text{vHydBuy}_{p,sc,n,hr})
+
+    #.  **Hydrogen Sales** (``vTotalHydTradeProfit``): The revenue generated from selling hydrogen to the market, as defined by ``eTotalHydTradeProfit``.
+
+        .. math::
+           \text{vTotalHydTradeProfit}_{p,sc,n} = \sum_{hr \in HR} \text{pDuration}_{p,sc,n} \times (\text{pVarEnergyPrice}_{hr,p,sc,n} \times \text{vHydSell}_{p,sc,n,hr})
 
 #.  **Generation Costs (`vTotalEleGCost`, `vTotalHydGCost`)**
     This is the operational cost of running the generation and production assets. It typically includes:
@@ -65,17 +75,55 @@ The total cost is broken down into several components, each represented by a spe
     *   **No-Load Costs**: The cost of keeping a unit online, even at minimum output.
     *   **Start-up and Shut-down Costs**: Costs incurred when changing a unit's commitment state.
 
+    The cost is defined by ``eTotalEleGCost`` for electricity and ``eTotalHydGCost`` for hydrogen.
+
+    .. math::
+       \text{vTotalEleGCost}_{p,sc,n} = \sum_{eg \in EG} \text{pDuration}_{p,sc,n} \times (
+       & \text{pEleGenLinearVarCost}_{eg} \times \text{vEleTotalOutput}_{p,sc,n,eg} + \\
+       & \text{pEleGenOMVariableCost}_{eg} \times \text{vEleTotalOutput}_{p,sc,n,eg}) + \\
+       & \sum_{egt \in EGT} \text{pDuration}_{p,sc,n} \times (
+       \text{pEleGenConstantVarCost}_{egt} \times \text{vEleGenCommitment}_{p,sc,n,egt} + \\
+       & \text{pEleGenStartUpCost}_{egt} \times \text{vEleGenStartUp}_{p,sc,n,egt} + \\
+       & \text{pEleGenShutDownCost}_{egt} \times \text{vEleGenShutDown}_{p,sc,n,egt})
+
+    .. math::
+       \text{vTotalHydGCost}_{p,sc,n} = \sum_{hg \in HG} \text{pDuration}_{p,sc,n} \times (
+       & \text{pHydGenLinearVarCost}_{hg} \times \text{vHydTotalOutput}_{p,sc,n,hg} - \\
+       & \text{pHydGenOMVariableCost}_{hg} \times \text{vHydTotalOutput}_{p,sc,n,hg}) + \\
+       & \sum_{hgt \in HGT} \text{pDuration}_{p,sc,n} \times (
+       \text{pHydGenConstantVarCost}_{hgt} \times \text{vHydGenCommitment}_{p,sc,n,hgt} + \\
+       & \text{pHydGenStartUpCost}_{hgt} \times \text{vHydGenStartUp}_{p,sc,n,hgt} + \\
+       & \text{pHydGenShutDownCost}_{hgt} \times \text{vHydGenShutDown}_{p,sc,n,hgt})
+
 #.  **Emission Costs (`vTotalECost`)**
-    This component captures the cost of carbon emissions from fossil-fueled generators. It is calculated by multiplying the CO2 emission rate of each generator by its output and the carbon price (`pParCO2Cost`).
+    This component captures the cost of carbon emissions from fossil-fueled generators. It is calculated by multiplying the CO2 emission rate of each generator by its output and the carbon price (`pGenCO2EmissionCost`). The formulation is defined by ``eTotalECost``.
+
+    .. math::
+       \text{vTotalECost}_{p,sc,n} = \sum_{egt \in EGT} \text{pDuration}_{p,sc,n} \times \text{pGenCO2EmissionCost}_{egt} \times \text{vEleTotalOutput}_{p,sc,n,egt}
 
 #.  **Consumption Costs (`vTotalEleCCost`, `vTotalHydCCost`)**
-    This represents the costs associated with operating energy consumers within the system, most notably the cost of power used to charge energy storage devices.
+    This represents the costs associated with operating energy consumers within the system, most notably the cost of power used to charge energy storage devices. These are defined by ``eTotalEleCCost`` and ``eTotalHydCCost``.
+
+    .. math::
+       \text{vTotalEleCCost}_{p,sc,n} = \sum_{egs \in EGS} \text{pDuration}_{p,sc,n} \times \text{pEleGenLinearTerm}_{egs} \times \text{vEleTotalCharge}_{p,sc,n,egs}
+
+    .. math::
+       \text{vTotalHydCCost}_{p,sc,n} = \sum_{hgs \in HGS} \text{pDuration}_{p,sc,n} \times \text{pHydGenLinearTerm}_{hgs} \times \text{vHydTotalCharge}_{p,sc,n,hgs}
 
 #.  **Reliability Costs (`vTotalEleRCost`, `vTotalHydRCost`)**
-    This is a penalty cost applied to any energy demand that cannot be met. It is calculated by multiplying the amount of unserved energy by a very high "value of lost load" (`pParENSCost`), ensuring the model prioritizes meeting demand.
+    This is a penalty cost applied to any energy demand that cannot be met. It is calculated by multiplying the amount of unserved energy by a very high "value of lost load" (`pParENSCost` or `pParHNSCost`), ensuring the model prioritizes meeting demand. The associated constraints are ``eTotalEleRCost`` and ``eTotalHydRCost``.
     *   Associated variables: ``vENS`` (Energy Not Supplied), ``vHNS`` (Hydrogen Not Supplied).
 
+    .. math::
+       \text{vTotalEleRCost}_{p,sc,n} = \sum_{ed \in ED} \text{pDuration}_{p,sc,n} \times \text{pParENSCost} \times \text{vENS}_{p,sc,n,ed}
+
+    .. math::
+       \text{vTotalHydRCost}_{p,sc,n} = \sum_{hd \in HD} \text{pDuration}_{p,sc,n} \times \text{pParHNSCost} \times \text{vHNS}_{p,sc,n,hd}
+
 #.  **Peak Demand Costs (`vTotalElePeakCost`)**
-    This component models capacity-based tariffs, where costs are determined by the highest power peak registered during a specific billing period (e.g., a month). This incents the model to "shave" demand peaks to reduce costs.
+    This component models capacity-based tariffs, where costs are determined by the highest power peak registered during a specific billing period (e.g., a month). This incents the model to "shave" demand peaks to reduce costs. The formulation is defined by ``eTotalElePeakCost``.
+
+    .. math::
+       \text{vTotalElePeakCost}_{p,sc} = \frac{1}{|\text{Peaks}|} \sum_{er \in ER} \text{pEleRetTariff}_{er} \times \text{factor1} \times \sum_{m \in \text{moy}} \sum_{\text{peak} \in \text{Peaks}} \text{vElePeak}_{p,sc,m,er,\text{peak}}
 
 By minimizing the sum of these components, the model finds the most economically efficient way to operate the system's assets to meet energy demand reliably.


### PR DESCRIPTION
This commit updates the documentation in `docs/rst/concepts/objective-and-costs.rst` to accurately reflect the mathematical formulations of the objective function and its various cost components as implemented in `src/el1xr_opt/Modules/oM_ModelFormulation.py`.

The following changes were made:
- The main objective function formula was corrected to include the proper indices and discounted components.
- Simplified or missing equations for Market, Generation, Emission, Consumption, Reliability, and Peak Demand costs were replaced with their detailed mathematical representations from the code.

This ensures that the documentation serves as a reliable and precise reference for the model's implementation.