### PR TITLE
Refactor directory path handling in EEM26 case extraction

### DIFF
--- a/data/EEM26/EEM26_extract_cases_v2.py
+++ b/data/EEM26/EEM26_extract_cases_v2.py
@@ -10,12 +10,12 @@ Improvements over the previous version:
 from __future__ import annotations
 
 import argparse
+import os
 import time
 import zipfile
 from itertools import product
 from pathlib import Path
 
-import os
 import py7zr
 import rarfile
 
@@ -99,11 +99,9 @@ def build_case_name(base_case: str, f0: str, f1: str, f2: str, f3: str, f4: str)
 
 def main() -> None:
     args = parse_args()
-    if args.cases_dir is not None:
-        base_dir = os.path.join(args.base_dir, args.cases_dir)
-    else:
-        base_dir = args.base_dir.resolve()
-    results_dir = (args.results_dir or (args.results_dir / "Results")).resolve()
+    base_dir = args.base_dir.resolve()
+    cases_dir = (args.cases_dir or (base_dir / "Cases")).resolve()
+    results_dir = (args.results_dir or (base_dir / "Results")).resolve()
     results_dir.mkdir(parents=True, exist_ok=True)
 
     t_total_start = time.time()
@@ -113,8 +111,8 @@ def main() -> None:
         print(f"Processing base case: {base_case}")
         print(f"{'='*60}")
 
-        archive_path = find_archive(base_dir, base_case)
-        print(f"  Searching for archive in: {base_dir}")
+        archive_path = find_archive(cases_dir, base_case)
+        print(f"  Searching for archive in: {cases_dir}")
         if archive_path is None:
             print(f"  WARNING: No archive found for {base_case}, skipping.")
             continue

--- a/data/EEM26/EEM26_extract_cases_v2.py
+++ b/data/EEM26/EEM26_extract_cases_v2.py
@@ -10,7 +10,6 @@ Improvements over the previous version:
 from __future__ import annotations
 
 import argparse
-import os
 import time
 import zipfile
 from itertools import product


### PR DESCRIPTION
## Summary
Refactored the directory path handling logic in the case extraction script to improve clarity and consistency in how base, cases, and results directories are resolved.

## Key Changes
- Reorganized import statements to follow alphabetical ordering (moved `os` import)
- Simplified `main()` function's directory initialization logic:
  - `base_dir` is now always resolved from `args.base_dir`
  - `cases_dir` is now explicitly defined with a default fallback to `base_dir / "Cases"` (previously implicit behavior)
  - `results_dir` logic remains similar but now uses `base_dir` as the reference point
- Updated `find_archive()` call to use the new `cases_dir` variable instead of `base_dir`
- Removed conditional logic that attempted to join paths using `os.path.join()`, replacing it with consistent `Path` object usage

## Implementation Details
The refactoring makes the directory structure more explicit and predictable:
- Previously, `cases_dir` was conditionally set by joining `base_dir` with `args.cases_dir` or defaulting to `args.base_dir`
- Now, `cases_dir` defaults to `base_dir / "Cases"` when not explicitly provided, making the default behavior clearer
- All path operations now consistently use `Path` objects and the `/` operator instead of mixing `os.path.join()` with `Path` objects

https://claude.ai/code/session_01WnXW2uBJBnStkDSXfB358F