### PR TITLE
Handle parent folder prefixes in archive extraction

### DIFF
--- a/data/EEM26/EEM26_extract_cases_v2.py
+++ b/data/EEM26/EEM26_extract_cases_v2.py
@@ -138,11 +138,9 @@ def main() -> None:
     args = parse_args()
     base_dir = args.base_dir.resolve()
 
-    raw_cases = args.cases_dir or Path("Cases")
-    cases_dir = (raw_cases if raw_cases.is_absolute() else base_dir / raw_cases).resolve()
+    cases_dir = (args.cases_dir or (base_dir / "Cases")).resolve()
 
-    raw_results = args.results_dir or Path("Results")
-    results_dir = (raw_results if raw_results.is_absolute() else base_dir / raw_results).resolve()
+    results_dir = (args.results_dir or (base_dir / "Results")).resolve()
     results_dir.mkdir(parents=True, exist_ok=True)
 
     t_total_start = time.time()

--- a/data/EEM26/EEM26_extract_cases_v2.py
+++ b/data/EEM26/EEM26_extract_cases_v2.py
@@ -78,29 +78,68 @@ def get_archive_names(archive_path: Path) -> list[str]:
             return z.getnames()
 
 
-def extract_files(archive_path: Path, out_dir: Path, targets: list[str]) -> None:
+def _write_member(data: bytes, archive_member: str, prefix: str, out_dir: Path) -> None:
+    """Write extracted bytes to out_dir, stripping the leading prefix from the member path."""
+    rel = archive_member[len(prefix):]  # strip parent folder, e.g. "Home1/"
+    dest = out_dir / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(data)
+
+
+def extract_files(archive_path: Path, out_dir: Path, targets: list[str], prefix: str = "") -> None:
+    if not prefix:
+        # No parent folder — extract directly as before
+        if archive_path.suffix == ".zip":
+            with zipfile.ZipFile(archive_path, "r") as z:
+                for t in targets:
+                    z.extract(t, path=out_dir)
+        elif archive_path.suffix == ".rar":
+            with rarfile.RarFile(archive_path, "r") as z:
+                for t in targets:
+                    z.extract(t, path=out_dir)
+        else:
+            with py7zr.SevenZipFile(archive_path, mode="r") as z:
+                z.extract(path=out_dir, targets=targets)
+        return
+
+    # Parent folder present — extract and strip the prefix
     if archive_path.suffix == ".zip":
         with zipfile.ZipFile(archive_path, "r") as z:
             for t in targets:
-                z.extract(t, path=out_dir)
+                _write_member(z.read(t), t, prefix, out_dir)
     elif archive_path.suffix == ".rar":
         with rarfile.RarFile(archive_path, "r") as z:
             for t in targets:
-                z.extract(t, path=out_dir)
+                _write_member(z.read(t), t, prefix, out_dir)
     else:
+        targets_set = set(targets)
         with py7zr.SevenZipFile(archive_path, mode="r") as z:
-            z.extract(path=out_dir, targets=targets)
+            for name, bio in z.read(targets).items():
+                if name in targets_set:
+                    _write_member(bio.read(), name, prefix, out_dir)
 
 
 def build_case_name(base_case: str, f0: str, f1: str, f2: str, f3: str, f4: str) -> str:
     return f"{base_case}_{f2}_{f1}_{f0}_{f3}_{f4}"
 
 
+def detect_archive_prefix(names_set: set[str], base_case: str) -> str:
+    """Return the parent-folder prefix if the archive has one (e.g. 'Home1/'), else ''."""
+    candidate = f"{base_case}/"
+    if any(n.startswith(candidate) for n in names_set):
+        return candidate
+    return ""
+
+
 def main() -> None:
     args = parse_args()
     base_dir = args.base_dir.resolve()
-    cases_dir = (args.cases_dir or (base_dir / "Cases")).resolve()
-    results_dir = (args.results_dir or (base_dir / "Results")).resolve()
+
+    raw_cases = args.cases_dir or Path("Cases")
+    cases_dir = (raw_cases if raw_cases.is_absolute() else base_dir / raw_cases).resolve()
+
+    raw_results = args.results_dir or Path("Results")
+    results_dir = (raw_results if raw_results.is_absolute() else base_dir / raw_results).resolve()
     results_dir.mkdir(parents=True, exist_ok=True)
 
     t_total_start = time.time()
@@ -124,17 +163,21 @@ def main() -> None:
         all_combos = list(product(FACTOR0, FACTOR1, FACTOR2, FACTOR3, FACTOR4))
         print(f"  Combinations : {len(all_combos)}")
 
+        t_start = time.time()
+
+        names_set = set(get_archive_names(archive_path))
+        prefix = detect_archive_prefix(names_set, base_case)
+        if prefix:
+            print(f"  Detected parent folder in archive: '{prefix.rstrip('/')}'")
+
         targets = []
         for f0, f1, f2, f3, f4 in all_combos:
             case_name = build_case_name(base_case, f0, f1, f2, f3, f4)
             for result_file in RESULT_FILES:
-                targets.append(f"{case_name}/{result_file}_{case_name}.csv")
+                targets.append(f"{prefix}{case_name}/{result_file}_{case_name}.csv")
 
         print(f"  Files to extract : {len(targets)}")
 
-        t_start = time.time()
-
-        names_set = set(get_archive_names(archive_path))
         missing = [t for t in targets if t not in names_set]
         if missing:
             print(f"  WARNING: {len(missing)} files not found in archive:")
@@ -147,7 +190,7 @@ def main() -> None:
             continue
 
         print(f"  Extracting {len(targets)} files...")
-        extract_files(archive_path, out_dir, targets)
+        extract_files(archive_path, out_dir, targets, prefix)
 
         elapsed = time.time() - t_start
         print(f"  Done : {base_case} -> {out_dir}")

--- a/data/EEM26/EEM26_extract_cases_v2.py
+++ b/data/EEM26/EEM26_extract_cases_v2.py
@@ -114,7 +114,10 @@ def extract_files(archive_path: Path, out_dir: Path, targets: list[str], prefix:
     else:
         targets_set = set(targets)
         with py7zr.SevenZipFile(archive_path, mode="r") as z:
-            for name, bio in z.read(targets).items():
+            files = z.read(targets)
+            if not files:
+                return
+            for name, bio in files.items():
                 if name in targets_set:
                     _write_member(bio.read(), name, prefix, out_dir)
 


### PR DESCRIPTION
## Summary
This PR improves the archive extraction logic to properly handle cases where archive contents are nested under a parent folder (e.g., all files under "Home1/"). Previously, the extraction would fail or create incorrect directory structures when archives had this layout.

## Key Changes
- **New `_write_member()` helper function**: Extracts bytes and strips the leading prefix from archive member paths before writing to disk, ensuring files are placed at the correct output location regardless of archive nesting.

- **Enhanced `extract_files()` function**: 
  - Added optional `prefix` parameter to handle parent folder stripping
  - Implements two extraction paths: direct extraction when no prefix exists, and prefix-stripping extraction when a parent folder is detected
  - Unified handling across all archive formats (ZIP, RAR, 7Z)

- **New `detect_archive_prefix()` function**: Automatically detects if archive contents are nested under a parent folder by checking if any member names start with `{base_case}/`.

- **Improved path resolution in `main()`**: Enhanced handling of relative vs. absolute paths for `cases_dir` and `results_dir` arguments, allowing more flexible configuration.

- **Updated target path construction**: Target file paths now include the detected prefix, ensuring correct matching against archive member names.

## Notable Implementation Details
- The prefix detection is case-sensitive and looks for the pattern `{base_case}/`
- When a prefix is detected, it's displayed to the user for transparency
- The extraction logic gracefully handles both prefixed and non-prefixed archives without requiring user intervention
- For 7Z files, the implementation properly handles the dictionary-based read interface

https://claude.ai/code/session_015FT34wkLrVzmFzt86X2Mhc