### PR TITLE
Improve archive prefix detection to handle nested case directories

### DIFF
--- a/data/EEM26/EEM26_extract_cases_v2.py
+++ b/data/EEM26/EEM26_extract_cases_v2.py
@@ -127,10 +127,17 @@ def build_case_name(base_case: str, f0: str, f1: str, f2: str, f3: str, f4: str)
 
 
 def detect_archive_prefix(names_set: set[str], base_case: str) -> str:
-    """Return the parent-folder prefix if the archive has one (e.g. 'Home1/'), else ''."""
+    """Return the parent-folder prefix if the archive has one (e.g. 'Home1/' or 'Cases/'), else ''."""
+    # Check for base_case/ prefix (e.g. 'Home1/')
     candidate = f"{base_case}/"
     if any(n.startswith(candidate) for n in names_set):
         return candidate
+    # Detect any other prefix by finding where 'base_case_' appears in archive paths
+    pattern = f"{base_case}_"
+    for name in names_set:
+        idx = name.find(pattern)
+        if idx > 0:
+            return name[:idx]
     return ""
 
 


### PR DESCRIPTION
## Summary
Enhanced the `detect_archive_prefix()` function to detect archive prefixes beyond the immediate base case folder, allowing it to identify parent directories when case files are nested deeper in the archive structure.

## Key Changes
- Updated docstring to clarify that the function can detect various prefix patterns (e.g., 'Home1/' or 'Cases/')
- Added fallback logic to detect prefixes by searching for the `base_case_` pattern in archive paths
- When a base case folder prefix is not found, the function now scans archive names to find where the base case pattern appears and extracts the parent directory path

## Implementation Details
The enhanced detection works in two stages:
1. First checks for the direct `base_case/` prefix (existing behavior)
2. If not found, searches for `base_case_` pattern in archive paths and returns everything before it as the prefix
- This handles cases where archive files are organized in nested directory structures with the base case name appearing as part of the file path rather than as an immediate parent folder

https://claude.ai/code/session_01FPzLifZLBTJgi85EaCfj2M