### PR TITLE
docs: add heat/investment/community to the formal concept tables; fix…

### DIFF
--- a/docs/rst/concepts/constraints.rst
+++ b/docs/rst/concepts/constraints.rst
@@ -1109,4 +1109,68 @@ To ensure numerical stability and solver efficiency, bounds are placed on key de
    -\phydmaxflow_{\periodindex,\scenarioindex,\timeindex,\busindexa,\busindexb,\circuitindex} \leq  \vhydflow_{\periodindex,\scenarioindex,\timeindex,\busindexa,\busindexb,\circuitindex}  \leq \phydmaxflow_{\periodindex,\scenarioindex,\timeindex,\busindexa,\busindexb,\circuitindex}
    \quad \forall \periodindex,\scenarioindex,\timeindex,\busindexa,\busindexb,\circuitindex|(\busindexa,\busindexb,\circuitindex) \in \nLH
 
+Heat sector
+-----------
+
+Built by ``oM_HeatSector.create_heat_sector`` only when a case carries heat data; see
+:doc:`heat-sector`.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - **Constraint**
+     - **Meaning**
+   * - ``eHeatBalance``
+     - Nodal heat balance: generation + store discharge + heat-pump output meet the
+       heat demand (minus heat-not-served).
+   * - ``eHeatPumpCOP``
+     - Heat-pump output = COP x electricity draw.
+   * - ``eHeatToEle``
+     - Heat-to-power electricity = efficiency x heat consumed.
+   * - ``eHeatInventory``
+     - Thermal-store inventory dynamics.
+
+The electricity balance ``eEleBalance`` additionally subtracts the heat-pump electricity
+load and adds the heat-to-power injection at each node.
+
+Investment / capacity sizing
+----------------------------
+
+Built by the investment layer for candidate units; see :doc:`features-and-modes`.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - **Constraint**
+     - **Meaning**
+   * - ``eEleInvestMaxOutput`` / ``eHydInvestMaxOutput``
+     - Candidate output limited by ``MaximumPower`` x build fraction.
+   * - ``eEleInvestMaxCharge`` / ``eHydInvestMaxCharge``
+     - Candidate electricity input limited by ``MaximumCharge`` x build fraction (for
+       storage charging and for the electrolyser's electricity input).
+   * - ``eEleInvestMaxInventory`` / ``eHydInvestMaxInventory``
+     - Candidate stored energy limited by ``MaximumStorage`` x build fraction.
+   * - ``eTotalICost``
+     - Total annualised investment cost (period-weighted, ``factor1``-scaled).
+
+Energy community and green hydrogen
+-----------------------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - **Constraint**
+     - **Meaning**
+   * - ``eEleCommunityPool``
+     - Per-zone lossless conservation of shared electricity (on with ``IndBinCommunity``);
+       the retail balance gains ``+ vEleShareIn - vEleShareOut``. See :doc:`community`.
+   * - ``eGreenH2Matching``
+     - RFNBO additionality: electrolyser electricity use is capped by available
+       renewable generation (on with ``pParGreenH2Matching``).
+   * - ``eEleMarketPPACost``
+     - Electricity PPA settlement for renewable units flagged ``pEleGenPPA``.
+
 

--- a/docs/rst/concepts/parameters.rst
+++ b/docs/rst/concepts/parameters.rst
@@ -415,3 +415,60 @@ Parameters specific to Electric Vehicle (EV) modeling.
      - Minimum EV battery state-of-charge at trip end
      - kWh
      - ``pEleMinStorageEnd``
+
+Heat sector
+-----------
+
+.. list-table::
+   :widths: 50 20 30
+   :header-rows: 1
+
+   * - **Description**
+     - **Unit**
+     - **Pyomo Component**
+   * - Heat generator maximum power
+     - kW
+     - ``pHeatGenMaxPower``
+   * - Heat generator running cost
+     - €/kWh
+     - ``pHeatGenCost``
+   * - Heat-pump coefficient of performance (heat / electricity)
+     - -
+     - ``pHeatPumpCOP``
+   * - Heat-to-power maximum heat input / efficiency
+     - kW, -
+     - ``pHeatToEleMaxHeat`` / ``pHeatToEleEff``
+   * - Thermal store maximum energy / round-trip efficiency / initial level
+     - kWh, -, kWh
+     - ``pHeatStoMax`` / ``pHeatStoEff`` / ``pHeatStoInitial``
+   * - Heat demand / heat-not-served cost
+     - kW, €/kWh
+     - ``pHeatDemand`` / ``pHeatNSCost``
+
+Investment and options
+----------------------
+
+.. list-table::
+   :widths: 50 20 30
+   :header-rows: 1
+
+   * - **Description**
+     - **Unit**
+     - **Pyomo Component**
+   * - Annualised investment cost of a candidate (electricity / hydrogen)
+     - €
+     - ``pEleGenInvestCost`` / ``pHydGenInvestCost``
+   * - Build a candidate as a binary (vs continuous fraction)
+     - 0/1
+     - ``pEleGenBinaryInvestment`` / ``pHydGenBinaryInvestment``
+   * - Build-fraction lower / upper bound
+     - -
+     - ``pEleGenInvestmentLo`` / ``...Up`` (and ``pHyd...``)
+   * - Period discount factor
+     - -
+     - ``pDiscountFactor``
+   * - Feature flags (unit commitment, ramps, single node, community, green-H2 matching, balance mode, ...)
+     - 0/1 / text
+     - ``pOptIndBin*``, ``pParGreenH2Matching``, ``pParBalanceMode``
+
+See :doc:`heat-sector` and :doc:`features-and-modes`.

--- a/docs/rst/concepts/results-and-postprocessing.rst
+++ b/docs/rst/concepts/results-and-postprocessing.rst
@@ -1,9 +1,22 @@
 Results & Post-Processing
 =========================
 
-After a successful optimization run, the model automatically post-processes the solution and saves a comprehensive set of results to the case directory (e.g., ``data/case_name/``). This is handled by the ``saving_results`` function in the ``oM_OutputData`` module.
+After a successful optimization run, the model post-processes the solution and saves the
+results. By default they go to ``<dir>/<case>/results.duckdb`` (one table per set,
+parameter, variable and constraint dual, plus an ``oM_Result_RunMetadata`` table), via
+``oM_OutputData_duckdb.save_to_duckdb``. Pass ``--rawresults True`` to also write the CSV
+result tables (``saving_results`` in ``oM_OutputData``), each prefixed ``oM_Result_``, and
+``--plots True`` for the HTML figures.
 
-The primary outputs are a series of CSV files, each prefixed with ``oM_Result_``, which provide detailed insights into the model's decisions. Several plots are also generated as HTML files.
+.. note::
+
+   When a case uses the heat sector, the investment layer or the energy community, their
+   decisions are saved too: the heat balance, the candidate build fractions and
+   investment cost, and the community sharing. The DuckDB output carries every variable,
+   so these appear there even when the curated CSV/plot set focuses on electricity.
+
+The primary CSV outputs are a series of files, each prefixed with ``oM_Result_``, which
+provide detailed insights into the model's decisions.
 
 Key Output Files
 ----------------

--- a/docs/rst/concepts/sets.rst
+++ b/docs/rst/concepts/sets.rst
@@ -120,12 +120,13 @@ Sets
    * - :math:`\nB`
      - Node or bus bar in the network
      - :code:`model.nd`
-   * - :math:`\nC`
-     - Electricity connection (from node, to node, circuit)
-     - :code:`model.cc`
    * - :math:`\nLE`
-     - Electricity arc (transmission line)
+     - Electricity arcs -- all input lines (from node, to node, circuit)
      - :code:`model.eln`
+   * - :math:`\nLE'`
+     - Electricity lines actually modelled (the subset of ``eln`` that passes the
+       reactance / transfer-capacity / period filters; used by the flow constraints)
+     - :code:`model.ela`
    * - :math:`\nLH`
      - Hydrogen arc (pipeline)
      - :code:`model.hpn`
@@ -183,9 +184,15 @@ General Technology Subsets
    * - :math:`\nGENR`
      - Non-renewable electricity generators (subset of :math:`\nGE`)
      - :code:`model.egnr`
-   * - :math:`\nGVRE`
-     - Variable Renewable Energy (VRE) generators (subset of :math:`\nGE`)
-     - :code:`model.egvre`
+   * - :math:`\nGR`
+     - Renewable (RES) electricity generators (subset of :math:`\nGE`)
+     - :code:`model.egr`
+   * - :math:`\nGT`
+     - Thermal (committable) electricity generators (subset of :math:`\nGE`)
+     - :code:`model.egt`
+   * - :math:`\nGV`
+     - Electric-vehicle units (subset of :math:`\nGE`)
+     - :code:`model.egv`
    * - :math:`\nEE`
      - Electricity energy storage systems (subset of :math:`\nGE`)
      - :code:`model.egs`
@@ -193,14 +200,68 @@ General Technology Subsets
      - All hydrogen production units
      - :code:`model.hg`
    * - :math:`\nGHE`
-     - Units converting electricity to hydrogen (e.g., electrolyzers)
+     - Units converting electricity to hydrogen, i.e. electrolysers (``e2h``)
      - :code:`model.e2h`
    * - :math:`\nGEH`
-     - Units converting hydrogen to electricity (e.g., fuel cells)
+     - Units converting hydrogen to electricity, i.e. fuel cells (``h2e``)
      - :code:`model.h2e`
    * - :math:`\nEH`
      - Hydrogen energy storage systems (subset of :math:`\nGH`)
      - :code:`model.hgs`
+
+Heat sector
+~~~~~~~~~~~
+
+.. list-table::
+   :widths: 30 50 30
+   :header-rows: 1
+
+   * - **Description**
+     - **Pyomo Component**
+     - **Notes**
+   * - Heat demands
+     - :code:`model.htd`
+     - per node via ``n2htd``
+   * - Heat generators (heat pumps and boilers)
+     - :code:`model.htg`
+     - per node via ``n2htg``
+   * - Heat pumps (electricity to heat, subset of ``htg``)
+     - :code:`model.htp`
+     - the cross-sector load on the electricity balance
+   * - Heat-to-power units (ORC / CHP)
+     - :code:`model.htw`
+     - per node via ``n2htw``
+   * - Thermal stores
+     - :code:`model.hts`
+     - per node via ``n2hts``
+
+See :doc:`heat-sector`.
+
+Investment / candidates
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 30 50 30
+   :header-rows: 1
+
+   * - **Description**
+     - **Pyomo Component**
+     - **Notes**
+   * - Electricity investment candidates (positive investment cost)
+     - :code:`model.egc`
+     - candidate generators / storage / fuel cells
+   * - Electricity storage candidates (subset of ``egc``)
+     - :code:`model.egsc`
+     -
+   * - Hydrogen investment candidates
+     - :code:`model.hgc`
+     - candidate electrolysers / storage
+   * - Hydrogen storage candidates (subset of ``hgc``)
+     - :code:`model.hgsc`
+     -
+
+The community layer additionally uses the zone/retailer mapping sets ``n2er`` / ``n2hr``
+and ``z2er`` (see :doc:`community`).
 
 Indices
 ~~~~~~~

--- a/docs/rst/concepts/variables.rst
+++ b/docs/rst/concepts/variables.rst
@@ -437,6 +437,40 @@ These binary (0 or 1) variables model on/off decisions, operational states, and 
      - '{0,1}'
      - ``vHydStorOperat``
 
+Heat, investment and community
+------------------------------
+
+.. list-table::
+   :widths: 50 20 30
+   :header-rows: 1
+
+   * - **Description**
+     - **Unit**
+     - **Pyomo Component**
+   * - Heat generator output / heat-pump electricity draw
+     - kW
+     - ``vHeatOutput`` / ``vHeatPumpElec``
+   * - Thermal store charge / discharge / inventory
+     - kW, kW, kWh
+     - ``vHeatCharge`` / ``vHeatDischarge`` / ``vHeatInventory``
+   * - Heat-to-power heat consumed / electricity produced
+     - kW
+     - ``vHeatConsumed`` / ``vHeatToEle``
+   * - Heat not served
+     - kW
+     - ``vHeatNotServed``
+   * - Candidate build fraction (electricity / hydrogen)
+     - -
+     - ``vEleGenInvest`` / ``vHydGenInvest``
+   * - Total (annualised) investment cost
+     - €
+     - ``vTotalICost``
+   * - Community electricity shared in / out (per member)
+     - kW
+     - ``vEleShareIn`` / ``vEleShareOut``
+
+See :doc:`heat-sector`, :doc:`features-and-modes` and :doc:`community`.
+
 Variable Bounding and Fixing
 ----------------------------
 

--- a/src/el1xr_opt/Modules/oM_Decomposition.py
+++ b/src/el1xr_opt/Modules/oM_Decomposition.py
@@ -1,18 +1,24 @@
-"""Decomposition and parallelization groundwork (scaffold).
+"""Benders decomposition and parallel block solving.
 
-See ``docs/decomposition.md`` for the design. This module marks out the block
-structure the model can be split along and gives a usable block partition, so
-that a Benders (and later Dantzig-Wolfe / column-generation) solver and parallel
-model building can be built on top. The actual decomposition loop is not
-implemented yet; the relevant entry points raise ``NotImplementedError``.
+See ``docs/decomposition.md`` for the design and ``docs/rst/user-guide/decomposition.rst``
+for the user-facing overview. The model is block-angular -- investment is the first
+stage, the operating problem separates by ``(period, scenario)`` and (for long horizons)
+by time window, with storage coupling the time windows -- so it can be solved by Benders
+instead of monolithically, reaching the same optimum.
 
-What is real now:
-  * ``partition_blocks`` returns the independent operating blocks of the problem.
-  * ``first_stage_components`` names the complicating and linking variables.
+Implemented and validated against the monolith:
+  * ``benders_solve`` -- the generic multi-cut L-shaped method (optimality cuts only,
+    with an elastic penalty making every block feasible for any first-stage decision).
+  * ``el1xr_benders`` -- the el1xr investment/operating split, with optional
+    process-parallel subproblem solves (``BendersConfig.n_workers``).
+  * ``el1xr_temporal_benders`` -- splits one operating horizon into time windows coupled
+    by the storage inventory at each boundary, with the fixed network charge counted once
+    in the master and the peak-demand charge handled as a threshold-LP linking variable.
+  * ``partition_blocks`` / ``first_stage_components`` -- the block partition and the
+    complicating / linking variable names.
 
-What is a stub:
-  * ``BendersConfig`` / ``solve_benders`` — the place to implement the loop,
-    mirroring openTEPES ``openTEPES_ProblemSolvingBenders``.
+The only stub is ``solve_benders(model, ...)``, a deprecated alias kept for the original
+scaffold signature; use ``el1xr_benders(dir, case, date, ...)`` instead.
 """
 from __future__ import annotations
 

--- a/src/el1xr_opt/Modules/oM_HeatSector.py
+++ b/src/el1xr_opt/Modules/oM_HeatSector.py
@@ -1,40 +1,35 @@
-"""Heat sector — scaffold (not yet wired into the solve pipeline).
+"""Heat sector -- a third energy carrier alongside electricity and hydrogen.
 
-The model today covers electricity and hydrogen. This module marks out where a
-third energy carrier, heat, will go, following the same pattern the electricity
-and hydrogen sectors already use. It is deliberately a scaffold: the input
-schema and the architecture already make room for heat, but the constraints
-below are not built yet and the function is not called from oM_Sequence.
+``create_heat_sector`` is wired into ``oM_Sequence.build_model`` (after the
+green-hydrogen step) and builds a behind-the-meter heat sector when the case
+carries heat data; it is a no-op otherwise, so electricity/hydrogen-only cases
+are unchanged.
 
-Planned scope (three settings, increasing in size):
+Scope today -- **home / residential heat**: a building-level, nodal heat demand
+met by a heat pump or boiler plus a thermal store, produced and used at the same
+node (no heat network yet -- district heating with pipe flows and losses is the
+planned next setting). The power-heat loop is open with a heat pump alone and
+closed by adding a heat-to-power unit.
 
-  * Home / residential heat: a building-level heat demand met by a heat pump or
-    boiler plus a thermal store. No heat network — heat is produced and used at
-    the same node, like a behind-the-meter battery.
-  * District heating: a heat network (pipes with losses) linking central
-    production (large heat pumps, CHP, boilers) to demand nodes, mirroring the
-    electricity and hydrogen network formulations.
+Input tables (read by ``load_heat_data``):
 
-Expected input tables (already listed in oM_InputSchema for forward
-compatibility; verify the exact columns against a real heat case before use):
+  * oM_Dict_HeatGeneration / oM_Data_HeatGeneration (with a ``Type`` column --
+    HeatPump / Boiler / Heat2Ele / Storage)
+  * oM_Data_HeatDemand / oM_Data_VarMaxHeatDemand
 
-  * oM_Dict_HeatGeneration / HeatDemand / HeatRetail
-  * oM_Data_HeatGeneration / HeatDemand / HeatRetail / HeatNetwork
-  * oM_Data_VarMaxHeatDemand / VarMinHeatDemand
+Sets, variables and constraints:
 
-Intended sets, variables and constraints (by analogy with the existing sectors):
+  * sets:        htg (heat generation), htp (heat pumps), htw (heat-to-power),
+                 hts (thermal storage), htd (heat demand)
+  * variables:   vHeatOutput, vHeatPumpElec, vHeatCharge / vHeatDischarge /
+                 vHeatInventory, vHeatConsumed, vHeatToEle, vHeatNotServed
+  * constraints: nodal heat balance (eHeatBalance), heat-pump coupling
+                 (eHeatPumpCOP), heat-to-power (eHeatToEle), thermal-store
+                 inventory (eHeatInventory).
 
-  * sets:        htg (heat generation), hts (thermal storage), htd (heat demand),
-                 htr (heat retail), hta (heat network arcs)
-  * variables:   vHeatTotalOutput, vHeatTotalCharge, vHeatInventory,
-                 vHeatDemand, vHNS (heat not served), vHeatNetFlow
-  * constraints: nodal heat balance, thermal-store inventory balance, heat-pump
-                 coupling (electricity in -> heat out via COP), network flow
-                 limits and losses for district heating.
-
-When implemented, call create_heat_sector(...) from oM_Sequence.routine right
-after create_green_hydrogen, and add the heat cost and revenue terms to the
-objective components.
+The heat-pump electricity draw and the heat-to-power injection are folded into
+the electricity balance, and the heat operating cost (period-discounted,
+duration-weighted) into the objective.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
… module docstrings

  Populate the sets/parameters/variables/constraints concept tables with the heat sector,
  investment layer and energy-community entries (and fix the bogus model.cc / egvre set
  references); correct the results page to DuckDB-default output; refresh the
  oM_HeatSector and oM_Decomposition module docstrings that still said 'scaffold'.