### PR TITLE
  fix: use the native Read the Docs badge in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ el1xr_opt
    :target: https://github.com/EL1XR-dev/el1xr_opt/actions/workflows/ci.yml
    :alt: GitHub Actions Workflow Status
 
-.. image:: https://img.shields.io/readthedocs/el1xr_opt
+.. image:: https://app.readthedocs.org/projects/el1xr-opt/badge/?version=latest
    :target: https://el1xr-opt.readthedocs.io/en/latest/
    :alt: Read the Docs
 


### PR DESCRIPTION
  The shields.io proxy badge showed "rate limited by upstream service"
  (Read the Docs rate-limits shields.io) and queried the wrong project
  slug (el1xr_opt; the RTD slug is el1xr-opt). The badge served directly
  by Read the Docs has neither problem.

  EOF