### PR TITLE
fix: guard initial-UC carry-over by UpTimeZero/DownTimeZero (C9)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -338,7 +338,13 @@ oM_InputData.py:837-840/862-865 set `pInitialUC = 1` whenever
 `UpTime - UpTimeZero > 0`, i.e. also when `UpTimeZero == 0` (the unit was never on),
 overriding the merit-order pre-commitment above it. The reference openTEPES logic has
 no such override. Produces a spurious first-step shut-down or masks a start-up.
-Should test `UpTimeZero > 0` (resp. `DownTimeZero > 0`).
+Should test `UpTimeZero > 0` (resp. `DownTimeZero > 0`). **— DONE (Part C item 5):**
+both carry-over conditions now require `UpTimeZero > 0` (resp. `DownTimeZero > 0`)
+before they fire, on both carriers (`pEleInitialUC` lines and the identical
+`pHydInitialUC` block). Latent in shipped cases (no shipped unit has a positive
+min-up/down requirement with a zero pre-horizon counter), so the goldens are
+unchanged; guarded in `tests/test_formulation_fixes.py`
+(`test_initial_uc_carryover_guarded_by_uptime_zero`).
 
 ### MED — asymmetries and conditional bugs
 

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -867,9 +867,13 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
                 parameters_dict['pEleInitialUC'    ][p,sc,go] = 1
                 parameters_dict['pEleSystemOutput' ]     += parameters_dict['pEleInitialOutput'][p,sc,go]
             # calculating if the unit was committed before of the time periods or not
-            if parameters_dict['pEleGenUpTime'][go] - parameters_dict['pEleGenUpTimeZero'][go] > 0:
+            # The carry-over only applies to a unit that was actually on (UpTimeZero > 0)
+            # but has not yet served its minimum up time; without the UpTimeZero guard a
+            # never-on unit (UpTimeZero == 0) would be force-committed, overriding the
+            # merit-order pre-commitment above. Symmetric for the down state.
+            if parameters_dict['pEleGenUpTimeZero'][go] > 0 and parameters_dict['pEleGenUpTime'][go] - parameters_dict['pEleGenUpTimeZero'][go] > 0:
                 parameters_dict['pEleInitialUC'][p,sc,go] = 1
-            if parameters_dict['pEleGenDownTime'][go] - parameters_dict['pEleGenDownTimeZero'][go] > 0:
+            if parameters_dict['pEleGenDownTimeZero'][go] > 0 and parameters_dict['pEleGenDownTime'][go] - parameters_dict['pEleGenDownTimeZero'][go] > 0:
                 parameters_dict['pEleInitialUC'][p,sc,go] = 0
 
     # determine the initial committed hydrogen units and their output
@@ -896,9 +900,12 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
                 parameters_dict['pHydInitialUC'    ][p,sc,hg] = 1
                 parameters_dict['pHydSystemOutput' ]     += parameters_dict['pHydInitialOutput'][p,sc,hg]
             # calculating if the unit was committed before of the time periods or not
-            if parameters_dict['pHydGenUpTime'][hg] - parameters_dict['pHydGenUpTimeZero'][hg] > 0:
+            # Same UpTimeZero/DownTimeZero guard as the electricity side: only a unit that
+            # was actually on (resp. off) before the horizon carries a remaining min-up
+            # (resp. min-down) obligation; a never-on unit must not be force-committed.
+            if parameters_dict['pHydGenUpTimeZero'][hg] > 0 and parameters_dict['pHydGenUpTime'][hg] - parameters_dict['pHydGenUpTimeZero'][hg] > 0:
                 parameters_dict['pHydInitialUC'][p,sc,hg] = 1
-            if parameters_dict['pHydGenDownTime'][hg] - parameters_dict['pHydGenDownTimeZero'][hg] > 0:
+            if parameters_dict['pHydGenDownTimeZero'][hg] > 0 and parameters_dict['pHydGenDownTime'][hg] - parameters_dict['pHydGenDownTimeZero'][hg] > 0:
                 parameters_dict['pHydInitialUC'][p,sc,hg] = 0
 
     # load levels multiple of cycles for each ESS/generator

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -362,6 +362,27 @@ def test_pre_horizon_commitment_fixing_uses_own_load_level():
             "commitment fixing must not use the stale loop variable n"
 
 
+def test_initial_uc_carryover_guarded_by_uptime_zero():
+    """C9: the pre-horizon min-up/min-down carry-over must only fire for a unit that was
+    actually on (``UpTimeZero > 0``) resp. off (``DownTimeZero > 0``) before the horizon.
+    ``UpTime - UpTimeZero > 0`` alone is true for a never-on unit (``UpTimeZero == 0``),
+    which would force ``pInitialUC = 1`` and override the merit-order pre-commitment. Both
+    carriers must carry the ``...TimeZero > 0`` guard."""
+    lines = open(INPUT_DATA, encoding="utf-8").read().splitlines()
+    for token in ("UpTime", "DownTime"):
+        for carrier in ("Ele", "Hyd"):
+            # the carry-over `if` condition references both the requirement and the
+            # pre-horizon counter for the carrier/state
+            cond = [ln for ln in lines
+                    if ln.lstrip().startswith("if ")
+                    and f"p{carrier}Gen{token}'][" in ln
+                    and f"p{carrier}Gen{token}Zero'][" in ln]
+            assert cond, f"missing {carrier} {token} carry-over condition"
+            for ln in cond:
+                assert f"p{carrier}Gen{token}Zero'][" in ln.split(" and ")[0], \
+                    f"{carrier} {token} carry-over must be guarded by {token}Zero > 0 first"
+
+
 def test_storage_charge_fcr_bounds_guard_zero_capacity():
     """C33: ``eEleFreqUpChargeBound`` / ``eEleFreqDownChargeBound`` divide by
     ``pEleMaxCharge``, so each rule must guard against a zero charge capacity (a


### PR DESCRIPTION
Part C audit item C9. The pre-horizon commitment carry-over fired on \`UpTime - UpTimeZero > 0\`, which is also true for a never-on unit (\`UpTimeZero == 0\`), so it force-committed that unit and overrode the merit-order pre-commitment. Adds the \`UpTimeZero > 0\` / \`DownTimeZero > 0\` guard on both the electricity and hydrogen sides.

Latent in shipped cases — golden tier (\`test_run.py\`) byte-unchanged (21 passed). New regression guard \`test_initial_uc_carryover_guarded_by_uptime_zero\` in \`test_formulation_fixes.py\` (31 passed).