### PR TITLE
fix: consistent duration/factor1 weighting of money terms (C15a, C16, C24)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -391,12 +391,26 @@ anywhere — so with `pParTimeStep > 1` they undercount by the time-step factor
 relative to the `'psn'` energy terms. (b) Conversely the start-up/shut-down costs sit
 inside `'psn'` terms and get multiplied by `pDuration`: a start at a k-hour level
 costs k times the start-up cost. Both are exact only at 1-hour resolution.
+**— (a) DONE (Part C item 5, branch `fix/duration-factor1-money-terms`):** each of the
+three volumetric terms now weights its inner sum over n by `pDuration[p,sc,n]`, so the
+per-kWh charge counts energy like the `'psn'` market terms. Latent at 1-hour resolution
+(`pDuration = 1`), so the goldens are byte-unchanged; guarded in
+`tests/test_formulation_fixes.py`. **(b) NOT done — own PR:** the per-event start-up /
+shut-down cost has to move out of the `'psn'`-aggregated `vTotalEleGCost` /
+`vTotalHydGCost` into a separate `'ps'` term (dividing by `pDuration` is unsafe — it can
+be 0 on a `psn` index when `pParTimeStep > 1`). That changes the cost-component
+breakdown, so it needs a deliberate golden re-baseline (like C1) and belongs in its own
+focused PR.
 
 C16. **factor1 is applied twice to the FCR prices.** `pOperatingReservePrice_*` is
 factor1-scaled at read (oM_InputData.py:150) and the three revenue constraints
 multiply by `model.factor1` again (:110,114,118). Latent at factor1=1; squares on the
 unit knob otherwise (same family as the C1 secondary and the storage-bound double
-scaling, C24).
+scaling, C24). **— DONE (Part C item 5, branch `fix/duration-factor1-money-terms`):**
+the redundant in-constraint `model.factor1` is removed from all three FCR revenue terms
+(`eEleMarketFCRDUpRevenue`/`FCRDDwRevenue`/`FCRNRevenue`), matching the day-ahead energy
+price convention (scaled once at read, raw in the constraint). Latent at factor1=1, so
+the goldens are byte-unchanged; guarded in `tests/test_formulation_fixes.py`.
 
 C17. **FCR revenue covers `egnr`, but caps and provisions cover only
 egt/egs/e2h.** A non-RES unit that is neither thermal (`ConstantVarCost == 0`) nor
@@ -454,7 +468,14 @@ C23. **Hydrogen charge upper bounds are never applied.** The bound loop tests
 C24. **Mixed single/double factor1 scaling of storage bounds.** `pVarMin/MaxStorage`
 are factor1-scaled at read and the inventory bounds + invest caps multiply by factor1
 again, while the `p*GenMaximumStorage` fallback is scaled once. Coincides only at
-factor1=1 (extends the Part B factor1-convention cleanup).
+factor1=1 (extends the Part B factor1-convention cleanup). **— DONE (Part C item 5,
+branch `fix/duration-factor1-money-terms`):** `VarMinStorage` / `VarMaxStorage` are now
+read unscaled (excluded from the `gen_frames_suffixes` factor1 loop), so the single
+factor1 is applied once at the inventory-bound / investment-cap sites — the same place
+the `GenMaximumStorage` fallback gets it, and consistent with the initial inventory
+(`pGenInitialStorage * factor1`, scaled once at read). Their only consumer is the
+`pVar*.replace(0, pGen*)` merge. Latent at factor1=1, so the goldens are byte-unchanged;
+guarded in `tests/test_formulation_fixes.py`.
 
 C25. **Hydrogen peak-indicator variables are declared on electricity-retailer sets
 but fixed over hydrogen-retailer sets.** `vHydPeakGlobalInd/MonthInd/DayInd` are

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -137,7 +137,12 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     for suffix in model.gen_frames_suffixes:
         # print(suffix)
         # parameters_dict[f'p{suffix}'] = data_frames[f'df{suffix}'][model.ehg] * factor1
-        parameters_dict[f'p{suffix}'] = data_frames[f'df{suffix}'].reindex(columns=model.ehg, fill_value=0.0) * factor1
+        # Storage energy bounds carry the factor1 unit conversion once, applied later at
+        # the inventory-bound / investment-cap sites (and the initial inventory). Read
+        # them unscaled here so the VarStorage path is not scaled twice relative to the
+        # GenMaximumStorage fallback, which is only scaled at those sites (C24).
+        scale = 1.0 if suffix in ('VarMinStorage', 'VarMaxStorage') else factor1
+        parameters_dict[f'p{suffix}'] = data_frames[f'df{suffix}'].reindex(columns=model.ehg, fill_value=0.0) * scale
 
     # Merging sets gg and hh
     model.ehr = model.err | model.hrr

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -76,7 +76,11 @@ def create_objective_function_components(model, optmodel, indlog):
 
     # Total electricity net usage costs
     def eTotalEleNetUseVarCost(optmodel, p,sc):
-        return (optmodel.vTotalEleNetUseVarCost[p,sc] == sum(sum(model.Par['pEleRetOverforingsavgift'][er] * model.factor1 * optmodel.vEleImport[p, sc, n, model.Par['pEleRetNode'][er]] for n in model.n) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er))
+        # volumetric grid fee per imported kWh: weight the per-level import power by
+        # pDuration so it counts energy, matching the duration-weighted "psn" market
+        # terms. Without it the charge undercounts by the time-step factor when
+        # pParTimeStep > 1 (C15a).
+        return (optmodel.vTotalEleNetUseVarCost[p,sc] == sum(sum(model.Par['pEleRetOverforingsavgift'][er] * model.factor1 * model.Par['pDuration'][p,sc,n] * optmodel.vEleImport[p, sc, n, model.Par['pEleRetNode'][er]] for n in model.n) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er))
     optmodel.__setattr__('eTotalEleNetUseVarCost', Constraint(optmodel.ps, rule=eTotalEleNetUseVarCost, doc='Total electricity net usage cost [kEUR]'))
 
     # Total electricity capacity tariff costs
@@ -107,15 +111,18 @@ def create_objective_function_components(model, optmodel, indlog):
     optmodel.__setattr__('eEleMarketFrequencyRevenue', Constraint(optmodel.psn, rule=eEleMarketFrequencyRevenue, doc='Total electricity market frequency revenues [kEUR]'))
 
     def eEleMarketFCRDUpRevenue(optmodel, p,sc,n):
-        return optmodel.vTotalEleFCRDUpRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * model.factor1 * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egnr]) for egnr in model.egnr) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * model.factor1 * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h]) for e2h in model.e2h)
+        # the FCR price is already factor1-scaled at read (oM_InputData), like the
+        # day-ahead energy price, so it must NOT be multiplied by factor1 again here
+        # (that squared it on the unit knob; latent at factor1=1) -- C16.
+        return optmodel.vTotalEleFCRDUpRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egnr]) for egnr in model.egnr) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h]) for e2h in model.e2h)
     optmodel.__setattr__('eEleMarketFCRDUpRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRDUpRevenue, doc='Total electricity market FCR-D upwards revenues [kEUR]'))
 
     def eEleMarketFCRDDwRevenue(optmodel, p,sc,n):
-        return optmodel.vTotalEleFCRDDwRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * model.factor1 * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egnr]) for egnr in model.egnr) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * model.factor1 * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]) for e2h in model.e2h)
+        return optmodel.vTotalEleFCRDDwRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egnr]) for egnr in model.egnr) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]) for e2h in model.e2h)
     optmodel.__setattr__('eEleMarketFCRDDwRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRDDwRevenue, doc='Total electricity market FCR-D downwards revenues [kEUR]'))
 
     def eEleMarketFCRNRevenue(optmodel, p,sc,n):
-        return optmodel.vTotalEleFCRNRev[p,sc,n] == sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * model.factor1 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egnr]) for egnr in model.egnr) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * model.factor1 * optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h]) for e2h in model.e2h)
+        return optmodel.vTotalEleFCRNRev[p,sc,n] == sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egnr]) for egnr in model.egnr) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h]) for e2h in model.e2h)
     optmodel.__setattr__('eEleMarketFCRNRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRNRevenue, doc='Total electricity market FCR-N revenues [kEUR]'))
 
     #%% Total hydrogen market costs
@@ -143,7 +150,7 @@ def create_objective_function_components(model, optmodel, indlog):
 
     # VAT on electricity taxes costs
     def eEleTaxEnergyCost(optmodel, p,sc):
-        return (optmodel.vTotalEleEnergyTaxCost[p,sc] == sum(model.Par['pEleRetEnergyTax'][er] * model.factor1 * sum(optmodel.vEleImport[p, sc, n, model.Par['pEleRetNode'][er]] for n in model.n) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er))
+        return (optmodel.vTotalEleEnergyTaxCost[p,sc] == sum(model.Par['pEleRetEnergyTax'][er] * model.factor1 * sum(model.Par['pDuration'][p,sc,n] * optmodel.vEleImport[p, sc, n, model.Par['pEleRetNode'][er]] for n in model.n) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er))
     optmodel.__setattr__('eEleTaxEnergyCost', Constraint(optmodel.ps, rule=eEleTaxEnergyCost, doc='Total electricity taxes costs [kEUR]'))
 
     def eEleTaxRevenue(optmodel, p,sc):
@@ -152,7 +159,7 @@ def create_objective_function_components(model, optmodel, indlog):
 
     # Incentives on electricity taxes revenues
     def eEleTaxISRevenue(optmodel, p,sc):
-        return (optmodel.vTotalEleISRev[p,sc] == sum(model.Par['pEleRetIncentive'][er] * model.factor1 * sum(optmodel.vEleExport[p, sc, n, model.Par['pEleRetNode'][er]] for n in model.n) for er in model.er))
+        return (optmodel.vTotalEleISRev[p,sc] == sum(model.Par['pEleRetIncentive'][er] * model.factor1 * sum(model.Par['pDuration'][p,sc,n] * optmodel.vEleExport[p, sc, n, model.Par['pEleRetNode'][er]] for n in model.n) for er in model.er))
     optmodel.__setattr__('eEleTaxISRevenue', Constraint(optmodel.ps, rule=eEleTaxISRevenue, doc='Total electricity taxes revenues [kEUR]'))
 
     #%% Total electricity operation and maintenance costs

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -383,6 +383,45 @@ def test_initial_uc_carryover_guarded_by_uptime_zero():
                     f"{carrier} {token} carry-over must be guarded by {token}Zero > 0 first"
 
 
+def test_volumetric_grid_charges_are_duration_weighted():
+    """C15a: the volumetric grid fee, energy tax and incentive revenue are per-kWh
+    charges on the per-level import/export power, aggregated as ``ps`` (no pDuration in
+    the registry). Each must therefore weight its inner sum over n by ``pDuration`` to
+    count energy, or it undercounts by the time-step factor when pParTimeStep > 1."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    for rule in ("eTotalEleNetUseVarCost", "eEleTaxEnergyCost", "eEleTaxISRevenue"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index("optmodel.__setattr__", start)]
+        assert "pDuration'][p,sc,n]" in body or "pDuration'][p, sc, n]" in body, \
+            f"{rule} must weight the per-level import/export by pDuration (C15a)"
+
+
+def test_fcr_revenue_price_not_double_factor1_scaled():
+    """C16: ``pOperatingReservePrice_*`` is factor1-scaled at read (oM_InputData), like
+    the day-ahead energy price, so the FCR revenue constraints must NOT multiply by
+    ``model.factor1`` again -- that squared factor1 on the unit knob."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    for rule in ("eEleMarketFCRDUpRevenue", "eEleMarketFCRDDwRevenue", "eEleMarketFCRNRevenue"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index("optmodel.__setattr__", start)]
+        assert "OperatingReservePrice" in body, f"{rule} body not found as expected"
+        assert "model.factor1" not in body, \
+            f"{rule} must not re-apply model.factor1 (price already scaled at read) (C16)"
+
+
+def test_storage_var_bounds_not_read_factor1_scaled():
+    """C24: ``pVarMinStorage`` / ``pVarMaxStorage`` must be read unscaled, because the
+    single factor1 unit conversion is applied later at the inventory-bound and
+    investment-cap sites (matching the GenMaximumStorage fallback and the initial
+    inventory). Scaling them at read too double-counts factor1 on the VarStorage path."""
+    text = open(INPUT_DATA, encoding="utf-8").read()
+    start = text.index("for suffix in model.gen_frames_suffixes:")
+    body = text[start:text.index("model.retail_frames_suffixes", start)]
+    assert "'VarMinStorage', 'VarMaxStorage'" in body or \
+           "('VarMinStorage', 'VarMaxStorage')" in body, \
+        "the storage Var suffixes must be excluded from the factor1 read-scaling (C24)"
+
+
 def test_storage_charge_fcr_bounds_guard_zero_capacity():
     """C33: ``eEleFreqUpChargeBound`` / ``eEleFreqDownChargeBound`` divide by
     ``pEleMaxCharge``, so each rule must guard against a zero charge capacity (a


### PR DESCRIPTION
Part C audit items C15(a), C16, C24 — money-term consistency, all latent at the shipped settings (factor1=1,
  1-hour steps), golden tier byte-unchanged (21 passed). C15(b) follows in its own PR (needs a golden re-baseline).
