### PR TITLE
fix: do not duration-weight per-event start-up/shut-down cost (C15b)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -395,12 +395,20 @@ costs k times the start-up cost. Both are exact only at 1-hour resolution.
 three volumetric terms now weights its inner sum over n by `pDuration[p,sc,n]`, so the
 per-kWh charge counts energy like the `'psn'` market terms. Latent at 1-hour resolution
 (`pDuration = 1`), so the goldens are byte-unchanged; guarded in
-`tests/test_formulation_fixes.py`. **(b) NOT done — own PR:** the per-event start-up /
-shut-down cost has to move out of the `'psn'`-aggregated `vTotalEleGCost` /
-`vTotalHydGCost` into a separate `'ps'` term (dividing by `pDuration` is unsafe — it can
-be 0 on a `psn` index when `pParTimeStep > 1`). That changes the cost-component
-breakdown, so it needs a deliberate golden re-baseline (like C1) and belongs in its own
-focused PR.
+`tests/test_formulation_fixes.py`. **(b) DONE (Part C item 5, branch
+`fix/c15b-startup-event-cost`):** the per-event start-up / shut-down cost is moved out of
+the `'psn'`-aggregated `vTotalEleGCost` / `vTotalHydGCost` into new `'ps'` terms
+`eTotalEleSUCost` / `eTotalHydSUCost` that sum over n without `pDuration` (dividing by
+`pDuration` would be unsafe — it can be 0 on a `psn` index when `pParTimeStep > 1`). The
+no-load `ConstantVarCost` stays in `GCost` (a EUR/h cost, correctly duration-weighted).
+The new terms are registered `'ps'` in the objective registry and added to the temporal
+Benders `TEMPORAL_HANDLED_PS_COST` allowlist (they are plain per-level sums, so each
+window sums its own start-ups). No re-baseline was needed after all: the goldens check
+only the total `eTotalSCost`, not the cost-component breakdown, and at 1-hour resolution
+(`pDuration = 1`) regrouping `'psn'`→`'ps'` leaves the total objective and the whole
+primal solution identical (solve tier byte-unchanged, temporal Benders == monolith).
+Guarded in `tests/test_formulation_fixes.py`; the C11 e2h-outside-`hgt` start-up test now
+checks `eTotalHydSUCost`.
 
 C16. **factor1 is applied twice to the FCR prices.** `pOperatingReservePrice_*` is
 factor1-scaled at read (oM_InputData.py:150) and the three revenue constraints

--- a/src/el1xr_opt/Modules/oM_Features.py
+++ b/src/el1xr_opt/Modules/oM_Features.py
@@ -291,7 +291,7 @@ def seed_objective_registry(model):
     Features may register additional terms after this."""
     model._cost_terms = []
     model._revenue_terms = []
-    for name in ("vTotalEleNCost", "vTotalEleXCost"):
+    for name in ("vTotalEleNCost", "vTotalEleXCost", "vTotalEleSUCost", "vTotalHydSUCost"):
         register_cost(model, name, "ps")
     for name in ("vTotalEleMCost", "vTotalHydMCost", "vTotalEleOCost", "vTotalHydOCost"):
         register_cost(model, name, "psn")
@@ -376,7 +376,10 @@ def register_horizon_unsupported(model, reason):
 # The "ps" composite cost/revenue terms the temporal split knows how to decompose. A
 # new per-(period, scenario) composite outside these is refused by the split's guard;
 # to handle it, register its non-separable parts above and extend these sets.
-TEMPORAL_HANDLED_PS_COST = {"vTotalEleNCost", "vTotalEleXCost"}
+# vTotalEleSUCost / vTotalHydSUCost are plain sums of per-event start-up/shut-down costs
+# over the load levels, so each window sums its own start-ups -- they split additively
+# across windows like the net-use/tax sums, with no master coordination.
+TEMPORAL_HANDLED_PS_COST = {"vTotalEleNCost", "vTotalEleXCost", "vTotalEleSUCost", "vTotalHydSUCost"}
 TEMPORAL_HANDLED_PS_REV = {"vTotalEleXRev"}
 
 

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1030,6 +1030,11 @@ def create_variables(model, optmodel, indlog):
     setattr(optmodel, 'vTotalEleGCost',                    Var(model.psn,     within=             Reals, doc='total variable electricity prod      cost                            [EUR]'))
     setattr(optmodel, 'vTotalHydGCost',                    Var(model.psn,     within=             Reals, doc='total variable hydrogen    prod      cost                            [EUR]'))
 
+    # electricity and hydrogen start-up / shut-down costs (per-event, ps-indexed so the
+    # objective does not duration-weight them; see eTotalEleSUCost / eTotalHydSUCost)
+    setattr(optmodel, 'vTotalEleSUCost',                   Var(model.ps ,     within=             Reals, doc='total electricity start-up/shut-down cost                            [EUR]'))
+    setattr(optmodel, 'vTotalHydSUCost',                   Var(model.ps ,     within=             Reals, doc='total hydrogen    start-up/shut-down cost                            [EUR]'))
+
     # electricity and hydrogen emission costs
     setattr(optmodel, 'vTotalEleECost',                    Var(model.psn,     within=             Reals, doc='total electricity   emission         cost                            [EUR]'))
 

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -169,12 +169,22 @@ def create_objective_function_components(model, optmodel, indlog):
 
     # Electricity generation operation cost [M€]
     def eTotalEleGCost(optmodel, p,sc,n):
+        # No-load (ConstantVarCost) is a EUR/h cost while committed, so it stays here and
+        # is correctly duration-weighted by the psn aggregation. The per-event start-up /
+        # shut-down costs were moved to eTotalEleSUCost (a ps term) so they are NOT
+        # duration-weighted -- a start at a k-hour level is one start, not k (C15b).
         return optmodel.vTotalEleGCost[p,sc,n] == (sum(model.Par['pEleGenLinearVarCost'  ][eg ] *       optmodel.vEleTotalOutput       [p,sc,n,eg ] for eg  in model.eg ) +
                                                    sum(model.Par['pEleGenConstantVarCost'][egt] *       optmodel.vEleGenCommitment     [p,sc,n,egt] for egt in model.egt) +
-                                                   sum(model.Par['pEleGenStartUpCost'    ][egt] *       optmodel.vEleGenStartUp        [p,sc,n,egt] for egt in model.egt) +
-                                                   sum(model.Par['pEleGenShutDownCost'   ][egt] *       optmodel.vEleGenShutDown       [p,sc,n,egt] for egt in model.egt) +
                                                    sum(model.Par['pEleGenOMVariableCost' ][eg ] *       optmodel.vEleTotalOutput       [p,sc,n,eg ] for eg  in model.eg ))
     optmodel.__setattr__('eTotalEleGCost', Constraint(optmodel.psn, rule=eTotalEleGCost, doc='Total electricity generation cost [kEUR]'))
+
+    # Electricity start-up / shut-down cost [M€] -- per-event, summed over the load
+    # levels WITHOUT pDuration (registered as a 'ps' objective term) so a start at a
+    # k-hour level costs one start-up, not k (C15b).
+    def eTotalEleSUCost(optmodel, p,sc):
+        return optmodel.vTotalEleSUCost[p,sc] == sum(sum(model.Par['pEleGenStartUpCost' ][egt] * optmodel.vEleGenStartUp [p,sc,n,egt] +
+                                                         model.Par['pEleGenShutDownCost'][egt] * optmodel.vEleGenShutDown[p,sc,n,egt] for egt in model.egt) for n in model.n)
+    optmodel.__setattr__('eTotalEleSUCost', Constraint(optmodel.ps, rule=eTotalEleSUCost, doc='Total electricity start-up/shut-down cost [kEUR]'))
 
     # Electricity generation emission cost [M€]
     def eTotalEleECost(optmodel, p,sc,n):
@@ -208,13 +218,21 @@ def create_objective_function_components(model, optmodel, indlog):
 
     # Hydrogen generation operation cost [M€]
     def eTotalHydGCost(optmodel, p,sc,n):
+        # As on the electricity side (C15b): no-load stays here (duration-weighted EUR/h);
+        # the per-event start-up / shut-down costs moved to eTotalHydSUCost (a ps term).
         return optmodel.vTotalHydGCost[p,sc,n] == (sum(model.Par['pHydGenLinearVarCost'  ][hg ] *       optmodel.vHydTotalOutput       [p,sc,n,hg ] for hg  in model.hg ) +
                                                    sum(model.Par['pHydGenConstantVarCost'][hgt] *       optmodel.vHydGenCommitment     [p,sc,n,hgt] for hgt in model.hgt) +
-                                                   sum(model.Par['pHydGenStartUpCost'    ][hgt] *       optmodel.vHydGenStartUp        [p,sc,n,hgt] for hgt in model.hgt) +
-                                                   sum(model.Par['pHydGenStartUpCost'    ][e2h] *       optmodel.vHydGenStartUp        [p,sc,n,e2h] for e2h in model.e2h if e2h not in model.hgt) +
-                                                   sum(model.Par['pHydGenShutDownCost'   ][hgt] *       optmodel.vHydGenShutDown       [p,sc,n,hgt] for hgt in model.hgt) +
                                                    sum(model.Par['pHydGenOMVariableCost' ][hg ] *       optmodel.vHydTotalOutput       [p,sc,n,hg ] for hg  in model.hg ))
     optmodel.__setattr__('eTotalHydGCost', Constraint(optmodel.psn, rule=eTotalHydGCost, doc='Total hydrogen generation cost [kEUR]'))
+
+    # Hydrogen start-up / shut-down cost [M€] -- per-event, summed over the load levels
+    # WITHOUT pDuration (a 'ps' objective term). The e2h start-up term covers an
+    # electrolyser outside hgt (zero fuel cost), preserving the C11 billing.
+    def eTotalHydSUCost(optmodel, p,sc):
+        return optmodel.vTotalHydSUCost[p,sc] == sum(sum(model.Par['pHydGenStartUpCost' ][hgt] * optmodel.vHydGenStartUp [p,sc,n,hgt] for hgt in model.hgt) +
+                                                     sum(model.Par['pHydGenStartUpCost' ][e2h] * optmodel.vHydGenStartUp [p,sc,n,e2h] for e2h in model.e2h if e2h not in model.hgt) +
+                                                     sum(model.Par['pHydGenShutDownCost'][hgt] * optmodel.vHydGenShutDown[p,sc,n,hgt] for hgt in model.hgt) for n in model.n)
+    optmodel.__setattr__('eTotalHydSUCost', Constraint(optmodel.ps, rule=eTotalHydSUCost, doc='Total hydrogen start-up/shut-down cost [kEUR]'))
 
     # Hydrogen consumption operation cost [M€]
     def eTotalHydCCost(optmodel, p,sc,n):

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -552,15 +552,48 @@ def test_fcr_activation_modulates_electrolyser_charge():
 
 def test_electrolyser_startup_cost_billed_outside_hgt():
     """C11: the cold-start cost must be billed for an electrolyser even when it is not in
-    ``hgt`` (zero fuel cost). ``eTotalHydGCost`` must add a start-up term over the e2h units
-    not in ``hgt``; the cold-start constraints are gated on the start-up cost alone, so the
-    cost must match."""
+    ``hgt`` (zero fuel cost). The start-up term over the e2h units not in ``hgt`` now lives
+    in ``eTotalHydSUCost`` (moved out of GCost by C15b); the cold-start constraints are
+    gated on the start-up cost alone, so the cost must match."""
     text = open(MODEL_FORMULATION, encoding="utf-8").read()
-    start = text.index("def eTotalHydGCost(")
-    end = text.index("rule=eTotalHydGCost", start)
+    start = text.index("def eTotalHydSUCost(")
+    end = text.index("rule=eTotalHydSUCost", start)
     body = text[start:end]
     assert "vHydGenStartUp" in body and "for e2h in model.e2h if e2h not in model.hgt" in body, \
         "start-up cost must cover e2h units outside hgt"
+
+
+def test_startup_cost_is_not_duration_weighted():
+    """C15b: per-event start-up / shut-down costs must NOT be duration-weighted. They are
+    moved out of the psn-aggregated GCost into a separate ps term (eTotal{Ele,Hyd}SUCost)
+    that sums over n without pDuration, and the SU terms are registered as 'ps' so the
+    objective does not multiply them by pDuration."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    # start-up / shut-down are gone from the duration-weighted generation cost
+    for rule in ("eTotalEleGCost", "eTotalHydGCost"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index(f"rule={rule}", start)]
+        assert "StartUp" not in body and "ShutDown" not in body, \
+            f"{rule} must not carry the per-event start-up/shut-down cost (C15b)"
+    # the new ps terms carry them and apply no pDuration
+    for rule in ("eTotalEleSUCost", "eTotalHydSUCost"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index(f"rule={rule}", start)]
+        assert "StartUp" in body and "ShutDown" in body, \
+            f"{rule} must sum the start-up and shut-down costs"
+        assert "pDuration" not in body, \
+            f"{rule} is a per-event cost and must not be weighted by pDuration (C15b)"
+    # both are registered as 'ps' (not duration-weighted) in the objective registry
+    feat = open(os.path.join(MODULES, "oM_Features.py"), encoding="utf-8").read()
+    seed = feat[feat.index("def seed_objective_registry("):feat.index("def aggregate_terms(")]
+    for name in ("vTotalEleSUCost", "vTotalHydSUCost"):
+        pos = seed.find(name)
+        assert pos != -1, f"{name} is not registered in seed_objective_registry (C15b)"
+        # the name sits in a `for name in (...): register_cost(model, name, "ps")` block;
+        # the register_cost call follows within the same block
+        window = seed[pos:pos + 200]
+        assert 'register_cost(model, name, "ps")' in window, \
+            f"{name} must be registered as a 'ps' cost term (C15b)"
 
 
 def test_electrolyser_has_no_ramp_or_mintime_constraint():


### PR DESCRIPTION
Part C audit item C15(b). Per-event start-up/shut-down costs were duration-weighted because they lived
  inside the psn-aggregated generation cost. Moved into separate ps-indexed terms (\`eTotalEleSUCost\` /
  \`eTotalHydSUCost\`) that sum over load levels without \`pDuration\`; no-load cost stays in GCost.

  Golden-neutral (the goldens check only the total \`eTotalSCost\`, identical at 1-hour resolution). All tiers green:
  formulation-fixes 35, golden+benders 25, temporal Benders 16 (== monolith), features/heat/etc. 30, sphinx -W clean.
  The C11 e2h-outside-hgt start-up test now checks \`eTotalHydSUCost\`.
