### PR TITLE
fix: close FCR reserve-provision and investment-coupling gaps (C17, C18, C21)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -429,12 +429,29 @@ such a unit. Related fragility: `pEleGenNoFCRD/N` get no `fillna` (oM_InputData.
 274-275), so a blank cell in a string-typed column is NaN — neither 0 nor 1 — and the
 unit escapes both the fixing and every FCR constraint while staying in the revenue
 sum. (The e2h flags got `.fillna(1)`; the electricity flags should too.)
+**— DONE (Part C item 5, branch `fix/fcr-bound-gaps`):** the three FCR revenue terms now
+pay over the backed providers (`egt` / `egs` / `e2h`) -- the same sets the caps and
+provisions cover -- instead of all of `egnr`, so a non-RES unit that is neither thermal
+nor storage is no longer paid for a free, unbounded bid. And `pEleGenNoFCRD` /
+`pEleGenNoFCRN` now get `.map(idxDict).fillna(1).astype('int')` like the e2h flags, so a
+blank cell defaults to "not participating" instead of NaN. Latent in shipped cases (an
+unbacked paid unit would already make the solve unbounded), so the goldens are
+byte-unchanged; guarded in `tests/test_formulation_fixes.py`.
 
 C18. **Static `pEleMaxCharge` fallback lets non-dischargeable units sell discharge
 reserve.** With `pEleGenNoDayAhead == 1` (or MaxPower ~ 0), the discharge-headroom
 constraints bound `DisUpDis + NorUpDis <= pEleMaxCharge` — a static charger rating
 with no SoC/commitment link; the compensating fix-to-zero for non-V2G units fires
 only when `NoDayAhead == 0` (oM_InputData.py:1542-1546).
+**— DONE (Part C item 5, branch `fix/fcr-bound-gaps`):** the discharge-headroom fallback
+branches (`eEleFreqUpDischargeHeadroom` / `eEleFreqDownDischargeHeadroom`) now bound the
+discharge reserve by the DISCHARGE rating `pEleMaxPower`, not the charge rating. A
+non-dischargeable unit (MaxPower ~ 0) then gets zero discharge headroom regardless of its
+`NoDayAhead` flag; a `NoDayAhead` unit with real MaxPower is bounded by MaxPower (its
+`output2ndBlock` is fixed to 0, so this matches the day-ahead branch). The compensating
+fix-to-zero is now redundant but harmless. Latent in shipped cases (no FCR storage unit
+has a zero discharge rating), goldens byte-unchanged; guarded in
+`tests/test_formulation_fixes.py`.
 
 C19. **Demand-only nodes get no balance — demand is silently dropped at zero
 cost.** The build guards of `eEleBalance`/`eHydBalance` (:425,436) count units and
@@ -459,6 +476,19 @@ electricity storage has all three caps) — an unbuilt store can absorb at namep
 and spill for free. (b) FCR-down headroom of candidate units (e2h :682, storage
 :574) uses the full nameplate, so a fractionally built unit can sell down-reserve on
 capacity it does not have.
+**— DONE (Part C item 5, branch `fix/fcr-bound-gaps`):** (a) new `eHydInvestMaxStorageCharge`
+caps `vHydTotalCharge` of a candidate hydrogen store by `pHydMaxCharge * build fraction`,
+mirroring the electricity storage charge cap. (b) the candidate branch of
+`eEleFreqDownChargeHeadroom` scales the storage nameplate by `vEleGenInvest` in place
+(linear, no commitment var there); the candidate electrolyser gets a separate build-cap
+constraint `eEleFreqDownChargeHeadroomConvInvest` bounding the reserve plus charge by
+`pHydMaxCharge2ndBlock * vHydGenInvest` (a separate constraint because the existing
+commitment-gated headroom already multiplies the nameplate by the commitment, and scaling
+by the build fraction too would be bilinear). Part (a) and the rest of the group are
+golden-neutral, but part (b) is real money: the FCR-providing battery *sizing* cases are
+candidates, so limiting their down-reserve to the built capacity raised their cost a
+little (~0.01%, net revenue down) -- their 5 goldens were deliberately re-baselined
+(HomeBattNoFCR, with no FCR, is unchanged). Guarded in `tests/test_formulation_fixes.py`.
 
 C22. **`vTotalEleDCost` is fixed to zero if *any* storage unit lacks DoD
 segments.** The fix sits inside `for egs in model.egs:` (oM_InputData.py:1372-1376),

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -293,8 +293,11 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     parameters_dict['pHydNetBinaryInvestment'  ] = parameters_dict['pHydNetBinaryInvestment'  ].map(idxDict)
     parameters_dict['pEleGenV2G'               ] = parameters_dict['pEleGenV2G'               ].map(idxDict)
     parameters_dict['pEleGenNoDayAhead'        ] = parameters_dict['pEleGenNoDayAhead'        ].map(idxDict)
-    parameters_dict['pEleGenNoFCRD'            ] = parameters_dict['pEleGenNoFCRD'            ].map(idxDict)
-    parameters_dict['pEleGenNoFCRN'            ] = parameters_dict['pEleGenNoFCRN'            ].map(idxDict)
+    # default 1 ("not participating") for a blank cell, like the e2h flags below; without
+    # the fillna a blank maps to NaN -- neither 0 nor 1 -- so the unit escapes both the
+    # bid fixing and every FCR constraint while still being paid revenue (C17).
+    parameters_dict['pEleGenNoFCRD'            ] = parameters_dict['pEleGenNoFCRD'            ].map(idxDict).fillna(1).astype('int')
+    parameters_dict['pEleGenNoFCRN'            ] = parameters_dict['pEleGenNoFCRN'            ].map(idxDict).fillna(1).astype('int')
     parameters_dict['pEleGenMaxCommitment'     ] = parameters_dict['pEleGenMaxCommitment'     ].map(idxDict)
     # Electrolyser (e2h) standby state and draw. When the hydrogen-generation data
     # omits these columns, standby is disabled (status 0) and the standby draw is 0,

--- a/src/el1xr_opt/Modules/oM_Investment.py
+++ b/src/el1xr_opt/Modules/oM_Investment.py
@@ -138,6 +138,14 @@ def create_investment(model, optmodel, indlog):
         return optmodel.vEleTotalCharge[p, sc, n, e2hc] <= model.Par['pHydMaxCharge'][e2hc][p, sc, n] * optmodel.vHydGenInvest[e2hc]
     optmodel.__setattr__('eHydInvestMaxCharge', Constraint(psne2hc, rule=eHydInvestMaxCharge, doc='candidate electrolyser electricity input limited by build decision'))
 
+    # Candidate hydrogen storage: hydrogen charge (inflow into the store). Like the
+    # electricity storage charge cap (eEleInvestMaxCharge), an unbuilt candidate store
+    # must not be able to absorb hydrogen at nameplate (and spill it for free); cap the
+    # charge by the build decision too (C21a).
+    def eHydInvestMaxStorageCharge(optmodel, p, sc, n, hgsc):
+        return optmodel.vHydTotalCharge[p, sc, n, hgsc] <= model.Par['pHydMaxCharge'][hgsc][p, sc, n] * optmodel.vHydGenInvest[hgsc]
+    optmodel.__setattr__('eHydInvestMaxStorageCharge', Constraint(psnhgsc, rule=eHydInvestMaxStorageCharge, doc='candidate hydrogen storage charge limited by build decision'))
+
     # %% Total investment cost
     # Unit scaling: model.factor1 is the conversion factor that lets the model work
     # at either utility (MWh) or local/home (kWh) scale. It is applied to the

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -114,15 +114,22 @@ def create_objective_function_components(model, optmodel, indlog):
         # the FCR price is already factor1-scaled at read (oM_InputData), like the
         # day-ahead energy price, so it must NOT be multiplied by factor1 again here
         # (that squared it on the unit knob; latent at factor1=1) -- C16.
-        return optmodel.vTotalEleFCRDUpRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egnr]) for egnr in model.egnr) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h]) for e2h in model.e2h)
+        # Pay revenue only over the backed FCR providers (egt / egs / e2h), the same sets
+        # the caps and bid-provision relations cover. Summing over all of egnr would also
+        # pay a non-RES unit that is neither thermal nor storage -- it has a bid variable
+        # but no cap, no provision and is never fixed, so its bid would be free and the
+        # paid revenue would make the objective unbounded (C17).
+        return optmodel.vTotalEleFCRDUpRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egt]) for egt in model.egt) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs]) for egs in model.egs) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h]) for e2h in model.e2h)
     optmodel.__setattr__('eEleMarketFCRDUpRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRDUpRevenue, doc='Total electricity market FCR-D upwards revenues [kEUR]'))
 
     def eEleMarketFCRDDwRevenue(optmodel, p,sc,n):
-        return optmodel.vTotalEleFCRDDwRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egnr]) for egnr in model.egnr) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]) for e2h in model.e2h)
+        # backed providers only (egt / egs / e2h), as in eEleMarketFCRDUpRevenue (C17)
+        return optmodel.vTotalEleFCRDDwRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egt]) for egt in model.egt) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs]) for egs in model.egs) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]) for e2h in model.e2h)
     optmodel.__setattr__('eEleMarketFCRDDwRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRDDwRevenue, doc='Total electricity market FCR-D downwards revenues [kEUR]'))
 
     def eEleMarketFCRNRevenue(optmodel, p,sc,n):
-        return optmodel.vTotalEleFCRNRev[p,sc,n] == sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egnr]) for egnr in model.egnr) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h]) for e2h in model.e2h)
+        # backed providers only (egt / egs / e2h), as in eEleMarketFCRDUpRevenue (C17)
+        return optmodel.vTotalEleFCRNRev[p,sc,n] == sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egt]) for egt in model.egt) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs]) for egs in model.egs) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h]) for e2h in model.e2h)
     optmodel.__setattr__('eEleMarketFCRNRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRNRevenue, doc='Total electricity market FCR-N revenues [kEUR]'))
 
     #%% Total hydrogen market costs
@@ -607,7 +614,11 @@ def create_constraints(model, optmodel, indlog):
             if  model.Par['pEleGenNoDayAhead'][egs] == 0 and model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
                 return optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs] <= model.Par['pEleMaxPower'][egs][p,sc,n] - optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs]
             else:
-                return optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs] <= model.Par['pEleMaxCharge'][egs][p,sc,n]
+                # Discharge reserve must be bounded by the DISCHARGE rating, not the charge
+                # rating: a non-dischargeable unit (MaxPower ~ 0) then has zero discharge
+                # headroom, and a NoDayAhead unit (output2ndBlock fixed to 0) is bounded by
+                # its MaxPower -- the same quantity as the branch above (C18).
+                return optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs] <= model.Par['pEleMaxPower'][egs][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqUpDischargeHeadroom', Constraint(optmodel.psnegs, rule=eEleFreqUpDischargeHeadroom, doc='FCR-D and FCR-N upward discharge headroom'))
@@ -624,13 +635,20 @@ def create_constraints(model, optmodel, indlog):
             if model.Par['pEleGenNoDayAhead'][egs] == 0 and model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
                 return optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs] <= optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs]
             else:
-                return optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs] <= model.Par['pEleMaxCharge'][egs][p,sc,n]
+                # bound the down-discharge reserve by the DISCHARGE rating, not the charge
+                # rating, so a non-dischargeable unit cannot sell it (C18)
+                return optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs] <= model.Par['pEleMaxPower'][egs][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqDownDischargeHeadroom', Constraint(optmodel.psnegs, rule=eEleFreqDownDischargeHeadroom, doc='FCR-D downward discharge headroom'))
 
     def eEleFreqDownChargeHeadroom(optmodel, p,sc,n,egs):
         if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+            # For a candidate storage unit cap the down-charge reserve by the BUILT charge
+            # capacity (nameplate * build fraction), so a fractionally built unit cannot
+            # sell down-reserve on capacity it has not built (C21b).
+            if egs in model.egsc:
+                return optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs] <= model.Par['pEleMaxCharge'][egs][p,sc,n] * optmodel.vEleGenInvest[egs] - optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs]
             return optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs] <= model.Par['pEleMaxCharge'][egs][p,sc,n] - optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs]
         else:
             return Constraint.Skip
@@ -743,6 +761,18 @@ def create_constraints(model, optmodel, indlog):
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqDownChargeHeadroomConv', Constraint(optmodel.psne2h, rule=eEleFreqDownChargeHeadroomConv, doc='FCR downward charge headroom for the electrolyser'))
+
+    # For a candidate electrolyser, also cap the down-charge reserve (plus the charge) by
+    # the BUILT input capacity (nameplate * build fraction), so a fractionally built unit
+    # cannot sell down-reserve on capacity it has not built. This is a separate constraint
+    # because the headroom above already multiplies the nameplate by the commitment, and
+    # multiplying by the build fraction too would be bilinear (C21b).
+    def eEleFreqDownChargeHeadroomConvInvest(optmodel, p,sc,n,e2h):
+        if e2h in model.hgc and ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)):
+            return optmodel.vEleFreqContReserveDisDownCha[p,sc,n,e2h] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,e2h] + optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h] <= model.Par['pHydMaxCharge2ndBlock'][e2h][p,sc,n] * optmodel.vHydGenInvest[e2h]
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleFreqDownChargeHeadroomConvInvest', Constraint(optmodel.psne2h, rule=eEleFreqDownChargeHeadroomConvInvest, doc='FCR downward charge headroom for a candidate electrolyser (build-limited)'))
 
     def eEleFreqUpChargeBoundConv(optmodel, p,sc,n,e2h):
         if ((model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)) and model.Par['pHydMaxCharge'][e2h][p,sc,n]:

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -409,6 +409,83 @@ def test_fcr_revenue_price_not_double_factor1_scaled():
             f"{rule} must not re-apply model.factor1 (price already scaled at read) (C16)"
 
 
+def test_fcr_revenue_paid_only_over_backed_providers():
+    """C17: the FCR revenue must be paid over the backed providers (egt / egs / e2h) --
+    the same sets the caps and provisions cover -- not over all of egnr. A non-RES unit
+    that is neither thermal nor storage has a free bid, no cap and no provision, so paying
+    it (via egnr) makes the objective unbounded."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    for rule in ("eEleMarketFCRDUpRevenue", "eEleMarketFCRDDwRevenue", "eEleMarketFCRNRevenue"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index("optmodel.__setattr__", start)]
+        assert "for egnr in model.egnr" not in body, \
+            f"{rule} must not pay revenue over all of egnr (unbounded objective) (C17)"
+        for s in ("for egt in model.egt", "for egs in model.egs", "for e2h in model.e2h"):
+            assert s in body, f"{rule} must pay revenue over the backed set ({s}) (C17)"
+
+
+def test_ele_fcr_flags_default_to_not_participating():
+    """C17: ``pEleGenNoFCRD`` / ``pEleGenNoFCRN`` must get ``.fillna(1)`` (like the e2h
+    flags), so a blank cell defaults to 'not participating' instead of NaN -- a NaN flag
+    is neither 0 nor 1, letting the unit escape the bid fixing and every FCR constraint
+    while still being paid revenue."""
+    text = open(INPUT_DATA, encoding="utf-8").read()
+    for flag in ("pEleGenNoFCRD", "pEleGenNoFCRN"):
+        line = next((ln for ln in text.splitlines()
+                     if f"parameters_dict['{flag}'" in ln and ".map(idxDict)" in ln), "")
+        assert ".fillna(1)" in line, \
+            f"{flag} must default a blank cell to 1 (not participating) via fillna(1) (C17)"
+
+
+def test_discharge_reserve_bounded_by_discharge_rating():
+    """C18: the discharge-headroom fallback (for a NoDayAhead or zero-MaxPower unit) must
+    bound the discharge reserve by the DISCHARGE rating (pEleMaxPower), not the charge
+    rating (pEleMaxCharge) -- otherwise a non-dischargeable unit sells phantom discharge
+    reserve on its charger rating."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    for rule in ("eEleFreqUpDischargeHeadroom", "eEleFreqDownDischargeHeadroom"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index("optmodel.__setattr__", start)]
+        # the Dis...Dis + Nor...Dis fallback must not bound by the charge rating
+        fallback = [ln for ln in body.splitlines()
+                    if "ReserveDis" in ln and "Dis[p,sc,n,egs]" in ln and "<=" in ln
+                    and "pEleMaxCharge" in ln]
+        assert not fallback, \
+            f"{rule} must not bound the discharge reserve by pEleMaxCharge (C18)"
+
+
+def test_candidate_hydrogen_storage_charge_capped_by_build():
+    """C21a: a candidate hydrogen storage unit's charge must be capped by its build
+    decision (like electricity storage), so an unbuilt store cannot absorb at nameplate."""
+    text = open(INVESTMENT, encoding="utf-8").read()
+    assert "def eHydInvestMaxStorageCharge(" in text, \
+        "missing the candidate hydrogen-storage charge cap (C21a)"
+    start = text.index("def eHydInvestMaxStorageCharge(")
+    body = text[start:text.index("optmodel.__setattr__", start)]
+    assert "vHydTotalCharge[p, sc, n, hgsc]" in body and "vHydGenInvest[hgsc]" in body, \
+        "the cap must bound vHydTotalCharge by pHydMaxCharge * build fraction (C21a)"
+
+
+def test_candidate_fcr_down_headroom_limited_by_build():
+    """C21b: the FCR-down charge headroom of a candidate unit must be limited by the build
+    fraction, not the full nameplate. Storage scales the nameplate by vEleGenInvest in
+    place; the electrolyser gets a separate build-cap constraint (the in-place version
+    would be bilinear with the commitment)."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    # storage: the candidate branch scales pEleMaxCharge by the build fraction
+    start = text.index("def eEleFreqDownChargeHeadroom(")
+    body = text[start:text.index("optmodel.__setattr__", start)]
+    assert "model.egsc" in body and "pEleMaxCharge'][egs][p,sc,n] * optmodel.vEleGenInvest[egs]" in body, \
+        "candidate storage down-charge headroom must scale by vEleGenInvest (C21b)"
+    # electrolyser: a separate build-cap constraint bounds the reserve by the build fraction
+    assert "def eEleFreqDownChargeHeadroomConvInvest(" in text, \
+        "missing the candidate electrolyser FCR-down build cap (C21b)"
+    start = text.index("def eEleFreqDownChargeHeadroomConvInvest(")
+    body = text[start:text.index("optmodel.__setattr__", start)]
+    assert "vHydGenInvest[e2h]" in body and "e2h in model.hgc" in body, \
+        "candidate electrolyser FCR-down build cap must bound by vHydGenInvest (C21b)"
+
+
 def test_storage_var_bounds_not_read_factor1_scaled():
     """C24: ``pVarMinStorage`` / ``pVarMaxStorage`` must be read unscaled, because the
     single factor1 unit conversion is applied later at the inventory-bound and
@@ -483,8 +560,11 @@ def test_fcr_down_headroom_is_state_gated():
     cannot sell down-reserve it could not absorb. It used the bare nameplate
     ``pHydMaxCharge`` with no state gate."""
     text = open(MODEL_FORMULATION, encoding="utf-8").read().splitlines()
+    # the commitment-gated headroom (exclude the separate C21b build-cap line, which
+    # bounds the same reserve by the build fraction rather than the commitment)
     body = [ln for ln in text if "vEleFreqContReserveDisDownCha[p,sc,n,e2h]" in ln
-            and "<=" in ln and "vEleTotalCharge2ndBlock" in ln]
+            and "<=" in ln and "vEleTotalCharge2ndBlock" in ln
+            and "vHydGenInvest" not in ln]
     assert body, "could not find the e2h FCR-down headroom rule"
     for ln in body:
         assert "pHydMaxCharge2ndBlock'][e2h][p,sc,n] * optmodel.vHydGenCommitment" in ln, \

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -112,12 +112,15 @@ SIZING_DIR = os.path.join(REPO, "data", "sizing")
 # test_h2_sizing_decisions, because the investment-cost share of the total cost
 # is below the cost tolerance.
 SIZING_CASES = [
-    pytest.param("HomeBatt",          44.27112550985886, id="HomeBatt"),
-    pytest.param("HoodBatt",         -22.04979393397224, id="HoodBatt"),
-    pytest.param("HomeBattNoTariff", 125.5211255098589,  id="HomeBattNoTariff"),
+    # FCR-active battery goldens re-baselined for C21b/C18: a candidate battery can no
+    # longer sell FCR-down reserve on unbuilt capacity, so it earns slightly less reserve
+    # revenue and the net cost rises a little. HomeBattNoFCR is unchanged (no FCR).
+    pytest.param("HomeBatt",          44.27655530263448, id="HomeBatt"),
+    pytest.param("HoodBatt",         -22.04188316124317, id="HoodBatt"),
+    pytest.param("HomeBattNoTariff", 125.5265553026345,  id="HomeBattNoTariff"),
     pytest.param("HomeBattNoFCR",    122.8894702739726,  id="HomeBattNoFCR"),
-    pytest.param("HomeBattFCRDonly",  67.89854138599155, id="HomeBattFCRDonly"),
-    pytest.param("HomeBattFCRNonly",  56.97418403620797, id="HomeBattFCRNonly"),
+    pytest.param("HomeBattFCRDonly",  67.90928111201895, id="HomeBattFCRDonly"),
+    pytest.param("HomeBattFCRNonly",  56.98016352651909, id="HomeBattFCRNonly"),
     pytest.param("H2Tank",            6774.093295025795, id="H2Tank"),
     pytest.param("Electrolyser",      6774.089825257397, id="Electrolyser"),
 ]


### PR DESCRIPTION
Part C audit items C17, C18, C21.

  - **C17** (unbounded objective): FCR revenue now pays over the backed providers (egt/egs/e2h), not all of egnr;
  electricity FCR flags get fillna(1) like the e2h flags.
  - **C18**: discharge reserve bounded by the discharge rating (pEleMaxPower), not the charge rating.
  - **C21a**: candidate hydrogen storage charge capped by the build decision.
  - **C21b**: candidate FCR-down charge headroom limited to the built capacity.

  C17/C18/C21a are golden-neutral. **C21b moved 5 goldens** (deliberate re-baseline): the FCR-providing battery sizing
  cases are candidates, so their cost rose ~0.01% (less reserve revenue). HomeBattNoFCR is unchanged — the consistency
  check that only FCR-active cases moved.

  All tiers green: formulation-fixes 40, golden 21 (post re-baseline), Benders + temporal Benders pass,
  features/heat/etc. 18, sphinx -W clean.
