### PR TITLE
fix: fixed-consumption electrolyser charge + degradation-cost mixed fleet (C12, C22)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -370,6 +370,13 @@ skips `eEleTotalCharge`'s e2h branch (:1255) and both `eE2HMax/MinCharge2ndBlock
 the 2nd-block fixing loop runs over `ehs = egs|hgs`, which excludes e2h
 (oM_InputData.py:362,1478-1490). `vEleTotalCharge[e2h]` is then free in
 `[0, MaxCharge]` with no commitment link, and `eAllEnergy2Hyd` still converts it.
+**— DONE (Part C item 5, branch `fix/storage-electrolyser-coupling`):** `eEleTotalCharge`
+gets a fixed-consumption e2h branch (`elif pHydMaxCharge`) that defines the charge as
+`MinCharge * commitment + StandByPower * standby` -- committed draws MinCharge, standby
+draws the standby power, off draws zero -- so the consumption is no longer free. The
+now-unused 2nd-block charge of such a unit is pinned to zero in the fixing block. Latent
+in shipped cases (every shipped electrolyser has a real 2nd block, MinCharge < MaxCharge),
+goldens byte-unchanged; guarded in `tests/test_formulation_fixes.py`.
 
 C13. **Electrolyser ramps and min-up/down times are now enforced nowhere.** The
 pure-load fix removed the (output-side) hydrogen-generator ramps and min-times for
@@ -495,7 +502,12 @@ segments.** The fix sits inside `for egs in model.egs:` (oM_InputData.py:1372-13
 so one non-degrading unit in a mixed fleet pins the *total* degradation-cost variable
 at zero while `eTotalEleDCost` equates it to the (nonzero) sum — erasing the
 degrading unit's cost or making the case infeasible. Aggregate the condition over all
-units first.
+units first. **— DONE (Part C item 5, branch `fix/storage-electrolyser-coupling`):** the
+total-cost fix is now gated by `all(DoDS1+DoDS2+DoDS3 == 0 for egs in model.egs)` and
+moved out of the per-unit loop, so the total is fixed to zero only when no storage unit
+degrades; the per-unit DoD-variable fixing stays inside the loop. Latent in shipped cases
+(no shipped case mixes a degrading and a non-degrading storage unit), goldens
+byte-unchanged; guarded in `tests/test_formulation_fixes.py`.
 
 C23. **Hydrogen charge upper bounds are never applied.** The bound loop tests
 `if idx in model.hg:` with `idx` the full `(p,sc,n,unit)` tuple
@@ -520,7 +532,11 @@ but fixed over hydrogen-retailer sets.** `vHydPeakGlobalInd/MonthInd/DayInd` are
 `Var(model.psner,...)` etc. but the tariff fixing loops index them with `psnhr`
 tuples (oM_InputData.py:1082-1104 vs 1422-1445) — `KeyError` as soon as a case has an
 active hydrogen retailer; they also appear in no constraint (dead apart from the
-broken fixing).
+broken fixing). **— ALREADY FIXED by C48 (same bug):** the indicators are now declared
+*and* fixed over the hydrogen retail sets `psnhr` / `psdhr` / `psdnhr`, guarded by
+`test_hydrogen_peak_indicators_on_hydrogen_sets`. They are still dead variables (no
+constraint references them) — the hydrogen peak-tariff cost layer itself is unbuilt, as
+noted under C48. Nothing further to do here.
 
 C26. **Compressor consumption is dead data.** `MaxCompressorConsumption` is read and
 unit-factored (oM_InputData.py:176) but referenced by no variable, constraint or

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1427,10 +1427,14 @@ def create_variables(model, optmodel, indlog):
 
     # fixing storage variables related to depth of discharge scenarios
     for idx in model.psd:
+        # The TOTAL degradation cost is zero only when NO storage unit degrades. Fixing it
+        # whenever ANY single unit lacks DoD segments (the old per-unit test) pinned the
+        # total to zero in a mixed fleet while eTotalEleDCost equates it to the nonzero sum
+        # -- erasing the degrading unit's cost or making the case infeasible (C22).
+        if all((model.Par['pEleGenDoDS1'][egs] + model.Par['pEleGenDoDS2'][egs] + model.Par['pEleGenDoDS3'][egs]) == 0 for egs in model.egs):
+            optmodel.__getattribute__(f'vTotalEleDCost')[idx].fix(0.0)
+            nFixedVariables += 1.0
         for egs in model.egs:
-            if (model.Par['pEleGenDoDS1'][egs] + model.Par['pEleGenDoDS2'][egs] + model.Par['pEleGenDoDS3'][egs]) == 0:
-                optmodel.__getattribute__(f'vTotalEleDCost')[idx].fix(0.0)
-                nFixedVariables += 1.0
             if (idx, egs) in model.psdegs and (model.Par['pEleGenDoDS1'][egs] + model.Par['pEleGenDoDS2'][egs] + model.Par['pEleGenDoDS3'][egs]) == 0:
                 optmodel.__getattribute__(f'vEleInventoryMinDay')[idx+(egs,)].fix(0.0)
                 nFixedVariables += 1.0
@@ -1656,6 +1660,15 @@ def create_variables(model, optmodel, indlog):
         hz = idx[-1]
         if not (hz in model.e2h and model.Par['pHydGenStandByStatus'][hz] == 1):
             optmodel.vHydGenStandBy[idx].fix(0.0)
+            nFixedVariables += 1
+
+    # A fixed-consumption electrolyser (MinCharge == MaxCharge, so MaxCharge2ndBlock == 0)
+    # has no charge decomposition: its total charge is set directly by the fixed-consumption
+    # branch of eEleTotalCharge, leaving the 2nd-block charge unused. Pin it to zero so it
+    # does not float (C12).
+    for idx in model.psne2h:
+        if model.Par['pHydMaxCharge2ndBlock'][idx[-1]][idx[:3]] == 0:
+            optmodel.vEleTotalCharge2ndBlock[idx].fix(0.0)
             nFixedVariables += 1
 
     # if there are no energy outflows no variable is needed

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -1364,6 +1364,13 @@ def create_constraints(model, optmodel, indlog):
                     return optmodel.vEleTotalCharge[p,sc,n,egs]                                           ==                                           optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + model.Par['pHydGenStandByPower'][egs] * optmodel.vHydGenStandBy[p,sc,n,egs] - model.Par['pOperatingReserveActivation_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs] + model.Par['pOperatingReserveActivation_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] - model.Par['pOperatingReserveActivation_FCRN_Up'][p,sc,n] * optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs] + model.Par['pOperatingReserveActivation_FCRN_Down'][p,sc,n] * optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]
                 else:
                     return optmodel.vEleTotalCharge[p,sc,n,egs] / model.Par['pHydMinCharge'][egs][p,sc,n] == optmodel.vHydGenCommitment[p,sc,n,egs] + (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] / model.Par['pHydMinCharge'][egs][p,sc,n]) + (model.Par['pHydGenStandByPower'][egs] / model.Par['pHydMinCharge'][egs][p,sc,n]) * optmodel.vHydGenStandBy[p,sc,n,egs] + (- model.Par['pOperatingReserveActivation_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs] + model.Par['pOperatingReserveActivation_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] - model.Par['pOperatingReserveActivation_FCRN_Up'][p,sc,n] * optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs] + model.Par['pOperatingReserveActivation_FCRN_Down'][p,sc,n] * optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pHydMinCharge'][egs][p,sc,n]
+            elif model.Par['pHydMaxCharge'][egs][p,sc,n]:
+                # Fixed consumption: MinCharge == MaxCharge so the 2nd block is empty. The
+                # charge is then not free -- it is MinCharge when committed plus the standby
+                # draw (a fixed-consumption unit cannot modulate, so no 2nd block and no FCR).
+                # Without this branch the constraint was skipped and vEleTotalCharge[e2h] was
+                # free in [0, MaxCharge] with no commitment link (C12).
+                return optmodel.vEleTotalCharge[p,sc,n,egs] == model.Par['pHydMinCharge'][egs][p,sc,n] * optmodel.vHydGenCommitment[p,sc,n,egs] + model.Par['pHydGenStandByPower'][egs] * optmodel.vHydGenStandBy[p,sc,n,egs]
             else:
                 return Constraint.Skip
         else:

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -383,6 +383,42 @@ def test_initial_uc_carryover_guarded_by_uptime_zero():
                     f"{carrier} {token} carry-over must be guarded by {token}Zero > 0 first"
 
 
+def test_fixed_consumption_electrolyser_charge_is_defined():
+    """C12: a fixed-consumption electrolyser (MinCharge == MaxCharge, so the 2nd block is
+    empty) must still have its total charge defined by commitment (MinCharge * uc + standby),
+    not left free. eEleTotalCharge needs a fixed-consumption branch, and the unused 2nd-block
+    charge must be pinned to zero."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    start = text.index("def eEleTotalCharge(")
+    body = text[start:text.index("optmodel.__setattr__('eEleTotalCharge'", start)]
+    assert "elif model.Par['pHydMaxCharge'][egs][p,sc,n]:" in body, \
+        "eEleTotalCharge needs a fixed-consumption (empty 2nd block) e2h branch (C12)"
+    assert "pHydMinCharge'][egs][p,sc,n] * optmodel.vHydGenCommitment[p,sc,n,egs]" in body, \
+        "the fixed-consumption charge must be MinCharge * commitment (+ standby) (C12)"
+    data = open(INPUT_DATA, encoding="utf-8").read()
+    assert "pHydMaxCharge2ndBlock'][idx[-1]][idx[:3]] == 0" in data \
+        and "vEleTotalCharge2ndBlock[idx].fix(0.0)" in data, \
+        "the unused 2nd-block charge of a fixed-consumption electrolyser must be pinned to 0 (C12)"
+
+
+def test_total_degradation_cost_fixed_only_if_no_unit_degrades():
+    """C22: the total electricity degradation cost may be fixed to zero only when NO storage
+    unit has DoD segments. Fixing it whenever ANY single unit lacks DoD (inside the per-unit
+    loop) erased a degrading unit's cost or made a mixed fleet infeasible -- it must be gated
+    by an aggregate ``all(...)`` over the units."""
+    text = open(INPUT_DATA, encoding="utf-8").read()
+    i = text.index("fixing storage variables related to depth of discharge")
+    block = text[i:i + 1200]
+    assert "all((model.Par['pEleGenDoDS1'][egs]" in block, \
+        "the vTotalEleDCost fix must be gated by all(... for egs in model.egs) (C22)"
+    # the total-cost fix must sit before the per-unit loop, not inside it
+    all_pos = block.index("all((model.Par['pEleGenDoDS1']")
+    loop_pos = block.index("for egs in model.egs:")
+    fix_pos = block.index("vTotalEleDCost')[idx].fix(0.0)")
+    assert all_pos < loop_pos and fix_pos < loop_pos, \
+        "the vTotalEleDCost fix must be aggregated before the per-unit loop, not inside it (C22)"
+
+
 def test_volumetric_grid_charges_are_duration_weighted():
     """C15a: the volumetric grid fee, energy tax and incentive revenue are per-kWh
     charges on the per-level import/export power, aggregated as ``ps`` (no pDuration in


### PR DESCRIPTION
Part C audit items C12 and C22 (and C25 confirmed already fixed by C48, doc-only close).

  - **C12**: a fixed-consumption electrolyser (MinCharge == MaxCharge) had its charge constraint skipped, leaving
  vEleTotalCharge[e2h] free with no commitment link. Added a fixed-consumption branch (MinCharge * commitment + standby)
  and pinned the unused 2nd block to zero.
  - **C22**: the total degradation cost was fixed to zero if any single storage unit lacked DoD segments
  (infeasible/erased in a mixed fleet). Now gated by all(...) over the units, moved out of the per-unit loop.
  - **C25**: confirmed resolved by C48 (peak indicators declared and fixed over the hydrogen sets); audit closed.

  Golden-neutral (no shipped fixed-consumption electrolyser or mixed degrading fleet). All tiers green:
  formulation-fixes 42, golden + all Benders + features/heat/etc. 59, sphinx -W clean.

  This completes every HIGH and MED item in Part C; only the LOW items (C28-C46) remain.
