### PR TITLE
Model audit cleanup: close remaining findings (C28–C46, C14)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -580,13 +580,22 @@ C33. `eEleFreqUp/DownChargeBound` (:581,591,598,608) divide by `pEleMaxCharge` w
 no positivity guard (the e2h analogues guard) — `ZeroDivisionError` for a
 discharge-only ESS with default flags.
 C34. With `pParNumberPowerPeaks == 0` the peak cost (:72) charges a power tariff
-with no kW quantity — a dimensionally meaningless constant.
+with no kW quantity — a dimensionally meaningless constant. **— DONE (warning, batch 2):
+the constant is a fixed objective offset, so it does not change the optimal solution
+(only the reported total cost). A load-time warning now fires when `pParNumberPowerPeaks
+== 0` and a non-zero `pEleRetPowerTariff` is set. Zeroing the offset would move any
+golden that hits this config, so it is left as an optional follow-up. Byte-unchanged.**
 C35. The per-unit binary relaxation loop (oM_InputData.py:1458-1462) never relaxes
 `vHydGenStandBy` and runs over `hgt` (skipping an e2h with `ConstantVarCost == 0`);
 in the LP default the three-state logic is continuously gameable (the demo correctly
-forces `binary_uc`). Document that standby results need binary UC.
+forces `binary_uc`). Document that standby results need binary UC. **— DONE (warning,
+batch 2): a load-time warning fires when a standby-capable electrolyser is run with
+relaxed commitment (`pOptIndBinGenOperat == 0`), stating the standby schedule needs
+binary UC to be meaningful. Byte-unchanged.**
 C36. `vHydGenShutDown[e2h] = 0` by design, but a nonzero `ShutDownCost` in the data
-(AEL_01: 1000) is silently ignored — deserves a load-time warning.
+(AEL_01: 1000) is silently ignored — deserves a load-time warning. **— DONE (warning,
+batch 2): a per-unit warning fires for any electrolyser with `ShutDownCost > 0`, noting
+the shut-down variable is fixed to zero so the cost is ignored. Byte-unchanged.**
 C37. Hydrogen storage outflow ramps (:1488,1498) reuse the *generation* ramp
 parameter `pHydGenRampUp/Down` where electricity had dedicated outflow-ramp
 parameters (commented out) — different physical limits.
@@ -596,7 +605,9 @@ per-unit-capacity (assert the convention); doc says `[MEUR]`, objective says
 `[kEUR]`.
 C39. A future-dated investment candidate (`InitialPeriod > base year`) is silently
 dropped from the model with no warning (the sizing generator works around it by
-rewriting `InitialPeriod`).
+rewriting `InitialPeriod`). **— DONE (warning, batch 2): after the generation sets are
+built, a warning lists any electricity or hydrogen unit dropped because its
+`InitialPeriod` is after the economic base year (single-period run). Byte-unchanged.**
 C40. Heat sector (oM_HeatSector.py): no `COP x heat-to-power efficiency < 1` data
 guard (a free power-heat-power loop is representable); the thermal store has no
 cyclic/terminal condition (initial stock is free energy, horizon ends empty); store
@@ -618,7 +629,13 @@ that activates a hydrogen retailer on a column-less file gets `KeyError` (no sch
 default, unlike the electricity peak factors).
 C44. The hydrogen day-ahead buy cost is stored in `vTotalHydMrkPPACost` under rule
 name `eHydMarketDayAheadCost` registered as `eTotalHydTradeCost` — misattributed in
-any report that greps by name.
+any report that greps by name. **— DONE (batch 2): the constraint attribute is renamed
+from `eTotalHydTradeCost` to `eHydMarketDayAheadCost`, matching its rule and the
+electricity analogue `eEleMarketDayAheadCost` (the old name was referenced nowhere else).
+The destination variable `vTotalHydMrkPPACost` actually holds the day-ahead trade cost;
+a comment records that the "PPA" in its name is historical, and the variable rename is
+deferred to avoid touching the objective registry and result-table columns. Byte-unchanged;
+guarded by `test_hydrogen_day_ahead_constraint_name_matches_rule`.**
 C45. Tautological `(NoDayAhead==1 or NoDayAhead==0)` conjuncts (:1057,1070,1100,
 1111) make the binary-gated 2nd-block branch unreachable for FCR-capable storage —
 dead logic; mutual exclusion still holds via the charge/discharge decisions.

--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -390,6 +390,25 @@ incident lines in its build guard but includes no flow/import/export term, so in
 multi-node case the retailer must cover the local imbalance as if the network
 delivered nothing (the commented-out `eEleBuyComposition` suggests the buy-import
 link was never finished). Correct only for single-node cases.
+**— ANALYSED, NOT CHANGED (batch 6): needs a modelling decision, flagged for the user.**
+The model carries two parallel balances: the PHYSICAL nodal balance `eEleBalance` (KCL with
+`vEleNetFlow` and grid `vEleImport`/`vEleExport`; grid fees/taxes/incentives are charged on
+`vEleImport`/`vEleExport`), and this COMMERCIAL per-retailer balance (the retailer's assigned
+generation/demand/charge closed by `vEleBuy`/`vEleSell`; the energy/day-ahead cost is charged
+on `vEleBuy`). Verified that EVERY shipped/sizing case has exactly ONE retailer (`EleR_01`)
+owning the entire portfolio (no unassigned generation or demand), so this balance sums the
+whole system and the network flows are internal to that single portfolio -- it is **correct
+as-is** for all goldens, which is why they pass. C14 only bites with **two or more retailers
+split across nodes** (no shipped case has this). The genuine missing piece is then NOT a flow
+term here (the flows are already in `eEleBalance`; adding them here would double-count) but the
+unfinished `vEleBuy` <-> `vEleImport` coupling that ties each retailer's commercial purchase to
+the physical grid import at its node. Designing that multi-retailer commercial/physical
+coupling is a real modelling task whose only effect is on multi-retailer multi-node cases, and
+it would re-baseline goldens on a chosen semantics. Rather than guess that semantics and risk
+baking an incorrect balance into the validated multi-node goldens, the code is left unchanged
+with a clarifying comment at the constraint; the design is flagged for the user. **Decision
+needed:** is the retail balance intended as a commercial portfolio balance (current behaviour,
+keep) or a true nodal balance, and how should `vEleBuy` couple to `vEleImport` per retailer?
 
 C15. **Duration weighting is inconsistent for several money terms.** (a) The
 volumetric grid fee (`eTotalEleNetUseVarCost`, :79), energy tax (:146) and incentive

--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -642,6 +642,24 @@ cyclic/terminal condition (initial stock is free energy, horizon ends empty); st
 charge/discharge bounds use the *energy* capacity as a power rating with no mutual
 exclusivity; a store-only node is missing from the heat-balance node list
 (`n2hts` not in the union); `vHeatNotServed` is uncapped.
+**— DONE (batch 5). No shipped/sizing golden carries heat tables, so all five are latent for
+the cost goldens; verified against `tests/test_heat_sector.py`. Fixes:**
+- **store-only node now in the balance node union (`n2hts` added), so a store on its own node
+  is constrained instead of free;**
+- **`vHeatNotServed` capped by demand (`eHeatNotServedCap`), so it cannot be a paid sink
+  (mirrors hydrogen C41);**
+- **thermal-store terminal condition added (`eHeatInventoryTerminal`: final inventory >=
+  initial), so the initial stock is not free energy drained over the horizon -- the
+  defensible default, matching the electricity store's cycle-time-step tie; chosen autonomously
+  and flagged (a strict `== initial` cyclic form is the alternative);**
+- **free power-heat-power loop now warned at load time when `COP x efficiency >= 1` (such a
+  loop makes the LP unbounded);**
+- **power-rating / mutual-exclusivity (charge/discharge bounded by the energy capacity, no
+  charge-XOR-discharge binary): DOCUMENTED as a known limitation -- harmless at the optimum
+  under `StoEff < 1`; a dedicated power-rating parameter + mutual-exclusivity binary is a
+  schema/MIP follow-up, not changed here.**
+**Guarded by `test_heat_store_terminal_and_not_served_cap`, `test_heat_store_only_node_enters_balance`,
+`test_power_heat_power_loop_warns`.**
 C41. Flexible hydrogen demand has no recovery constraint (unlike
 `eEleDemandShiftBalance`) and `vHNS <= pVarMaxDemand` regardless of the flexed
 demand — `vHydDemand - vHNS` can go negative (a paid sink).

--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -554,9 +554,16 @@ hydrogen-generation CSV without the columns crashes.
 C28. `eE2HMinCharge2ndBlock` (:1128-1133) is vacuous: `2ndBlock/Max >= uc - 1` with a
 NonNegative LHS and a nonpositive RHS can never bind. The state chain rests entirely
 on the Max constraint (which suffices for FCR-up; see C3 for the down side).
+**— DONE (documented, batch 1): this is a standard openTEPES min-2nd-block symmetry
+row (like `eHydMinESSOutput2ndBlock` / `eHydMinOutput2ndBlock`), non-binding by design,
+not a bug. A comment at the constraint records this; no logic change.**
 C29. The `>= 0` gates on `pOperatingReserveRequire_*` (27 sites) are always true
 (the parameter is `fillna(0)` and clamped); clearly meant `> 0`. No wrong solutions,
-just dead gating and redundant rows.
+just dead gating and redundant rows. **— DONE (batch 1): all 28 per-unit FCR build
+gates flipped `>= 0` -> `> 0`, so a zero-requirement level skips the dead rows; the
+requirement caps (count-gated, not requirement-gated) still bind the bids to zero, so
+the FCR goldens (HomeBattFCRDonly/FCRNonly, ElectrolyserFCR) are byte-unchanged. Guarded
+by `test_reserve_require_gates_use_strict_positive`.**
 C30. The endurance constraints (storage :620-632 and e2h :705-716) pair the level-n
 inventory with the bid at n-1 and skip `n.first()`, so the **last** level's bid is in
 no endurance constraint — end-of-horizon bids are free of the energy backing.
@@ -565,7 +572,10 @@ a symmetric product the deliverable volume is the *minimum*. Exact when the inpu
 are equal (the usual case).
 C32. RES units get FCR bid variables (declared over `eg|e2h`) that are in no cap, no
 relation, no revenue, and are never fixed — dead variables that can carry arbitrary
-values into the output tables.
+values into the output tables. **— DONE (batch 1): the existing FCR fixing loops run
+over `psnegnr` (non-RES) and `psne2h`, never touching `egr`; a new loop over `model.psnegr`
+fixes the three RES bid variables to zero. They enter no constraint or objective term, so
+the goldens are byte-unchanged. Guarded by `test_res_fcr_bid_variables_are_fixed`.**
 C33. `eEleFreqUp/DownChargeBound` (:581,591,598,608) divide by `pEleMaxCharge` with
 no positivity guard (the e2h analogues guard) — `ZeroDivisionError` for a
 discharge-only ESS with default flags.
@@ -598,6 +608,11 @@ C41. Flexible hydrogen demand has no recovery constraint (unlike
 demand — `vHydDemand - vHNS` can go negative (a paid sink).
 C42. `eEleInflows2Commitment` / `Outflows2Commitment` families (:730-756, 954-980)
 contain no commitment variable despite name and doc — parameter-bound duplicates.
+**— DONE (documented, batch 1): the misleading "to commitment" doc strings and the two
+section comments are corrected to state these bound the in/outflow variable by its
+parameter limit (the commitment-coupled form was never wired). The attribute name
+`...2Commitment` is deliberately retained to avoid renaming the constraint in result/.lp
+output — a separate cosmetic refactor. Guarded by `test_inflow_outflow_bound_docs_not_commitment`.**
 C43. `pHydRetMaxBuy/Sell` exist only if the optional CSV columns do — the first case
 that activates a hydrogen retailer on a column-less file gets `KeyError` (no schema
 default, unlike the electricity peak factors).
@@ -607,6 +622,11 @@ any report that greps by name.
 C45. Tautological `(NoDayAhead==1 or NoDayAhead==0)` conjuncts (:1057,1070,1100,
 1111) make the binary-gated 2nd-block branch unreachable for FCR-capable storage —
 dead logic; mutual exclusion still holds via the charge/discharge decisions.
+**— DONE (batch 1): the always-true conjunct is removed from the four ESS 2nd-block
+output/charge bounds. Behaviour is unchanged (an always-true `and` term drops out), so
+the goldens are byte-unchanged. The binary-gated `else` branch stays reachable only for
+non-FCR storage, as before; making it FCR-reachable would be a separate modelling
+decision. Guarded by `test_no_tautological_nodayahead_conjunct`.**
 C46. First-step electricity ramp (:1340,1350) uses `pEleSystemOutput` — a *system*
 aggregate, and a scalar overwritten across (p,sc) so only the last scenario's value
 survives — as each unit's pre-horizon output; essentially vacuous for small units.

--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -622,7 +622,15 @@ documented follow-up -- a data-schema decision, not changed here. Guarded by
 C38. `eTotalICost` multiplies the lump-sum annualized investment cost by `factor1`
 (oM_Investment.py:162) — dimensionally suspect unless `FixedInvestmentCost` is
 per-unit-capacity (assert the convention); doc says `[MEUR]`, objective says
-`[kEUR]`.
+`[kEUR]`. **— DONE (documented, batch 4): unit labels fixed -- `vTotalICost` is added
+directly to the `[EUR]` operating-cost components in `eTotalSCost` with no conversion, so
+its `[MEUR]` label was wrong; it and the objective doc are now `[EUR]`. The factor1
+multiplication is documented as the asserted convention: it is dimensionally consistent
+only because EVERY objective term is scaled by factor1, so factor1 is a global objective
+scalar that does not change the argmin (build-vs-operate trade-off invariant under the unit
+choice). All shipped cases run at factor1 == 1 (a no-op), so this is latent; a factor1 != 1
+regression test is the documented follow-up. Doc-only, byte-unchanged; guarded by
+`test_investment_cost_unit_label_consistent`.**
 C39. A future-dated investment candidate (`InitialPeriod > base year`) is silently
 dropped from the model with no warning (the sizing generator works around it by
 rewriting `InitialPeriod`). **— DONE (warning, batch 2): after the generation sets are

--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -567,9 +567,22 @@ by `test_reserve_require_gates_use_strict_positive`.**
 C30. The endurance constraints (storage :620-632 and e2h :705-716) pair the level-n
 inventory with the bid at n-1 and skip `n.first()`, so the **last** level's bid is in
 no endurance constraint — end-of-horizon bids are free of the energy backing.
+**— DONE (batch 3, GOLDENS RE-BASELINED): three additive terminal-level constraints
+(`eEleStorageEnduranceUpEnd` / `DownEnd` for storage, `eEleFreqDownEnduranceConvEnd` for the
+e2h node) back the last load level's FCR bid with the last level's inventory/store headroom
+(the inventory one period ahead does not exist). The interior rolling constraints are
+unchanged. This removes a free end-of-horizon reserve bid, so the four sizing cases that
+exploited it cost a little more: HoodBatt -22.042 -> -19.989, HomeBattFCRNonly 56.980 ->
+57.350, H2Tank 6774.093 -> 6776.720, Electrolyser 6774.090 -> 6776.716 (all UP, the correct
+direction). The other goldens were not bidding at the last level and are unchanged. Guarded by
+`test_terminal_endurance_constraints_exist`.**
 C31. The FCR-N volume cap (:466) uses the *average* of the up/down requirements; for
 a symmetric product the deliverable volume is the *minimum*. Exact when the inputs
-are equal (the usual case).
+are equal (the usual case). **— DONE (batch 3): the volume cap now uses
+`min(Require_FCRN_Up, Require_FCRN_Down)`; the FCR-N revenue price average is a separate,
+legitimate term and is untouched. Byte-unchanged in every shipped/sizing case because the
+FCR-N up and down requirements are equal there (min == avg), so no golden moved. Guarded by
+`test_fcrn_volume_cap_uses_minimum_not_average`.**
 C32. RES units get FCR bid variables (declared over `eg|e2h`) that are in no cap, no
 relation, no revenue, and are never fixed — dead variables that can carry arbitrary
 values into the output tables. **— DONE (batch 1): the existing FCR fixing loops run
@@ -598,7 +611,14 @@ batch 2): a per-unit warning fires for any electrolyser with `ShutDownCost > 0`,
 the shut-down variable is fixed to zero so the cost is ignored. Byte-unchanged.**
 C37. Hydrogen storage outflow ramps (:1488,1498) reuse the *generation* ramp
 parameter `pHydGenRampUp/Down` where electricity had dedicated outflow-ramp
-parameters (commented out) — different physical limits.
+parameters (commented out) — different physical limits. **— DONE (documented, batch 3):
+a comment at the H2 charge/outflow ramp records that it reuses the generation ramp because
+no dedicated hydrogen outflow-ramp parameter exists in the input schema (the electricity
+side defines `pEleGenOutflowsRampUp/Down` but leaves the matching constraint commented out,
+so electricity storage has no outflow ramp at all). Adding a dedicated `pHydGenOutflowsRamp*`
+parameter with a fallback to the generation ramp (keeping existing cases unchanged) is the
+documented follow-up -- a data-schema decision, not changed here. Guarded by
+`test_h2_storage_ramp_reuse_is_documented`.**
 C38. `eTotalICost` multiplies the lump-sum annualized investment cost by `factor1`
 (oM_Investment.py:162) — dimensionally suspect unless `FixedInvestmentCost` is
 per-unit-capacity (assert the convention); doc says `[MEUR]`, objective says
@@ -647,6 +667,11 @@ decision. Guarded by `test_no_tautological_nodayahead_conjunct`.**
 C46. First-step electricity ramp (:1340,1350) uses `pEleSystemOutput` — a *system*
 aggregate, and a scalar overwritten across (p,sc) so only the last scenario's value
 survives — as each unit's pre-horizon output; essentially vacuous for small units.
+**— DONE (batch 3): both first-step ramp branches now use the unit's own
+`pEleInitialOutput[p,sc,egt]` (per-unit, indexed over `ps * eg`) instead of the system
+scalar. Latent in every shipped/sizing golden (none has a thermal `egt` unit with an active
+ramp at the first level), so no golden moved. Guarded by
+`test_first_step_ramp_uses_per_unit_initial_output`.**
 C47. `pHydRetTariffType` is read by the peak-variable fixing loops but never created —
 the hydrogen retail file carries no `TariffType` column, so the first case that
 activates a hydrogen retailer crashes with `KeyError` (same family as C43). **— FIXED

--- a/src/el1xr_opt/Modules/oM_HeatSector.py
+++ b/src/el1xr_opt/Modules/oM_HeatSector.py
@@ -167,6 +167,19 @@ def create_heat_sector(model, optmodel, indlog='False', dir_name=None, case_name
     htw = list(getattr(model, "htw", []) or [])        # heat-to-power units (ORC/CHP)
     hts = list(getattr(model, "hts", []) or [])
     levels = list(model.n)
+
+    # Audit C40: a power -> heat-pump (COP) -> heat -> heat-to-power (efficiency) -> power
+    # loop produces net electricity whenever COP x efficiency >= 1. A heat pump's COP is
+    # normally > 1 (it moves free ambient heat the model does not account for), so the loop
+    # can be a perpetual-motion source that makes the LP unbounded. Warn when the data allows
+    # it (a store in the loop only adds StoEff <= 1, so COP x efficiency is the worst case).
+    if htp and htw:
+        max_cop = max((float(Par["pHeatPumpCOP"][g]) for g in htp), default=0.0)
+        max_eff = max((float(Par["pHeatToEleEff"][w]) for w in htw), default=0.0)
+        if max_cop * max_eff >= 1.0:
+            print(f"WARNING (C40): a power-heat-power loop is representable (max COP {max_cop} x "
+                  f"max heat-to-power efficiency {max_eff} = {max_cop * max_eff:.3f} >= 1); the "
+                  f"model may be unbounded. Ensure COP x efficiency < 1 or that the loop cannot close.")
     # all time-varying quantities are indexed by (period, scenario, load level),
     # like the electricity and hydrogen sectors. psn is the model's (p, sc, n) list.
     psn = list(getattr(model, "psn", None)
@@ -199,6 +212,12 @@ def create_heat_sector(model, optmodel, indlog='False', dir_name=None, case_name
     setattr(optmodel, "vHeatOutput", Var(_idx(htg), within=NonNegativeReals,
             bounds=lambda mm, p, sc, n, g: (0, float(Par["pHeatGenMaxPower"][g]))))
     setattr(optmodel, "vHeatPumpElec", Var(_idx(htp), within=NonNegativeReals))
+    # Audit C40 (documented limitation): charge/discharge are bounded by the store's ENERGY
+    # capacity (pHeatStoMax) used as a power rating -- there is no separate charge/discharge
+    # power-rating parameter in the heat schema, and there is no binary mutual-exclusivity
+    # forcing charge XOR discharge. Simultaneous charge+discharge is never beneficial under
+    # StoEff < 1 (it only loses energy), so it does not occur at the optimum; a dedicated
+    # power-rating parameter and a mutual-exclusivity binary are the follow-up (schema/MIP).
     setattr(optmodel, "vHeatCharge", Var(_idx(hts), within=NonNegativeReals,
             bounds=lambda mm, p, sc, n, s: (0, float(Par["pHeatStoMax"][s]))))
     setattr(optmodel, "vHeatDischarge", Var(_idx(hts), within=NonNegativeReals,
@@ -213,9 +232,13 @@ def create_heat_sector(model, optmodel, indlog='False', dir_name=None, case_name
             bounds=lambda mm, p, sc, n, w: (0, float(Par["pHeatToEleMaxHeat"][w]))))
     setattr(optmodel, "vHeatToEle", Var(_idx(htw), within=NonNegativeReals))
 
+    # Audit C40: include thermal-store nodes (n2hts) in the balance node list. A node with
+    # only a store (no demand/generation/heat-to-power) was previously omitted, so its store
+    # charge/discharge entered no balance and was free.
     nodes = sorted({nd for (nd, _u) in getattr(model, "n2htd", [])}
                    | {nd for (nd, _u) in getattr(model, "n2htg", [])}
-                   | {nd for (nd, _u) in getattr(model, "n2htw", [])})
+                   | {nd for (nd, _u) in getattr(model, "n2htw", [])}
+                   | {nd for (nd, _u) in getattr(model, "n2hts", [])})
     bal_idx = [(p, sc, n, nd) for (p, sc, n) in psn for nd in nodes]
 
     def _balance(mm, p, sc, n, nd):
@@ -260,6 +283,24 @@ def create_heat_sector(model, optmodel, indlog='False', dir_name=None, case_name
                                             - mm.vHeatDischarge[p, sc, n, s]))
     optmodel.eHeatInventory = Constraint(_idx(hts), rule=_inv,
                                          doc="thermal store inventory balance")
+
+    # Audit C40: cap heat-not-served by the demand it stands for, so it cannot exceed the
+    # demand and act as a free paid sink (mirrors the hydrogen eHydNotServedCap, C41).
+    def _ns_cap(mm, p, sc, n, d):
+        return mm.vHeatNotServed[p, sc, n, d] <= float(Par["pHeatDemand"][d].get((p, sc, n), 0.0))
+    optmodel.eHeatNotServedCap = Constraint(_idx(htd), rule=_ns_cap,
+                                            doc="heat not-served bounded by demand (C40)")
+
+    # Audit C40: terminal condition for the thermal store. The rolling balance starts from
+    # pHeatStoInitial and leaves the final inventory free, so the initial stock is a free
+    # energy supply the horizon can drain. Require the final inventory to be at least the
+    # initial stock, so the starting energy is not consumed for free (the electricity store
+    # gets the analogous tie via its cycle-time-step inventory; the heat store had none).
+    def _inv_terminal(mm, p, sc, s):
+        return mm.vHeatInventory[p, sc, model.n.last(), s] >= float(Par["pHeatStoInitial"][s])
+    optmodel.eHeatInventoryTerminal = Constraint(
+        [(p, sc, s) for (p, sc) in getattr(model, "ps", []) for s in hts],
+        rule=_inv_terminal, doc="thermal store terminal condition: final inventory >= initial (C40)")
 
     # heat operating cost (heat-not-served + generator running cost), discounted by
     # period and weighted by the load-level duration like the electricity and hydrogen

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -378,6 +378,20 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     model.hgsc = Set(doc='hydrogen storage       units ', initialize=[hgsc   for hgsc in           model.hgs if  parameters_dict['pHydGenInvestCost']      [hgsc]  >  0.0])
     model.e2h  = Set(doc='ele2hyd                units ', initialize=[hg     for hg   in           model.hg  if  parameters_dict['pHydGenProductionFunction'][hg]  >  0.0])
     model.h2e  = Set(doc='hyd2ele                units ', initialize=[eg     for eg   in           model.eg  if  parameters_dict['pEleGenProductionFunction'][eg]  >  0.0])
+    # Audit C39: a generation unit whose InitialPeriod is after the economic base year is
+    # dropped from the active sets above (single-period model). That is correct here, but it
+    # used to happen silently; warn so a future-dated candidate is not lost unnoticed.
+    _base_year = parameters_dict['pParEconomicBaseYear']
+    for _g in model.egg:
+        if _g not in model.eg and parameters_dict['pEleGenInitialPeriod'][_g] > _base_year:
+            print(f"WARNING (C39): electricity unit '{_g}' has InitialPeriod "
+                  f"{parameters_dict['pEleGenInitialPeriod'][_g]} > base year {_base_year} and is "
+                  f"dropped from the model (single-period run).")
+    for _g in model.hgg:
+        if _g not in model.hg and parameters_dict['pHydGenInitialPeriod'][_g] > _base_year:
+            print(f"WARNING (C39): hydrogen unit '{_g}' has InitialPeriod "
+                  f"{parameters_dict['pHydGenInitialPeriod'][_g]} > base year {_base_year} and is "
+                  f"dropped from the model (single-period run).")
     # Hydrogen analogue of egr (electricity RES). There is no hydrogen RES column,
     # so this set is empty; it exists because the initial-output loop references it
     # the same way the electricity loop references egr.
@@ -978,6 +992,14 @@ def create_variables(model, optmodel, indlog):
     # model.Peaks   = Set(initialize=[ i for i in range(1,4,1)]) # number of selected peaks hours
     if model.Par['pParNumberPowerPeaks'] == 0:
         model.Peaks   = RangeSet(1)
+        # Audit C34: with no power peaks the peak-cost constraint (eTotalElePeakCost) charges
+        # the power tariff with no kW quantity -- a constant added to the objective. It does
+        # not change the optimal solution (a fixed offset), but it does shift the reported
+        # total cost. Warn if a power tariff is configured so the offset is not mistaken for a
+        # real peak charge; set pEleRetPowerTariff to 0 (or pParNumberPowerPeaks > 0) to avoid it.
+        if sum(model.Par['pEleRetPowerTariff'][er] for er in model.er) > 0:
+            print("WARNING (C34): pParNumberPowerPeaks == 0 but a non-zero pEleRetPowerTariff is "
+                  "set; the peak cost becomes a constant objective offset with no kW quantity.")
     else:
         model.Peaks   = RangeSet(model.Par['pParNumberPowerPeaks']) # number of selected peaks hours
 
@@ -1657,10 +1679,27 @@ def create_variables(model, optmodel, indlog):
     # electrolyser's state logic uses commitment (on), standby and start-up (cold start);
     # it carries no shut-down transition, so its shut-down variable is fixed to zero too
     # (otherwise it would be a free variable appearing only in the shut-down cost).
+    # Audit C36: because the shut-down variable is fixed to zero, a nonzero ShutDownCost on
+    # an electrolyser is silently ignored. Warn so the data author is not misled.
+    for e2h in model.e2h:
+        if model.Par['pHydGenShutDownCost'][e2h] > 0:
+            print(f"WARNING (C36): electrolyser '{e2h}' has ShutDownCost > 0, but its shut-down "
+                  f"variable is fixed to zero (no shut-down transition is modelled), so the "
+                  f"shut-down cost is ignored.")
     for idx in model.psne2h:
         optmodel.vHydTotalOutput2ndBlock[idx].fix(0.0)
         optmodel.vHydGenShutDown[idx].fix(0.0)
         nFixedVariables += 2
+
+    # Audit C35: the three-state (on / standby / off) electrolyser logic is only meaningful
+    # with binary unit commitment. Under the LP relaxation (pOptIndBinGenOperat == 0) the
+    # commitment and standby variables are continuous, so the standby state is gameable and
+    # the reported standby schedule should not be trusted. Warn when both hold.
+    if model.Par['pOptIndBinGenOperat'] == 0 and \
+            any(e2h in model.e2h and model.Par['pHydGenStandByStatus'][e2h] == 1 for e2h in model.e2h):
+        print("WARNING (C35): a standby-capable electrolyser is run with relaxed (continuous) "
+              "unit commitment (pOptIndBinGenOperat == 0); the three-state standby logic is "
+              "gameable in the LP and standby results need binary UC to be meaningful.")
 
     # Standby is an electrolyser (e2h) state, available only where StandByStatus is set.
     # Everywhere else the standby variable is fixed to zero, so the three-state model

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1643,6 +1643,15 @@ def create_variables(model, optmodel, indlog):
             optmodel.vEleFreqContReserveNorDownCha[idx].fix(0.0)
             nFixedVariables += 3
 
+    # RES generators carry FCR bid variables (declared over eg) but appear in no FCR
+    # cap, relation, or revenue term, so they are never otherwise constrained. Fix them
+    # to zero so they cannot carry arbitrary values into the result tables (audit C32).
+    for idx in model.psnegr:
+        optmodel.vEleFreqContReserveDisUpwardBid[idx].fix(0.0)
+        optmodel.vEleFreqContReserveDisDownwardBid[idx].fix(0.0)
+        optmodel.vEleFreqContReserveNorBid[idx].fix(0.0)
+        nFixedVariables += 3
+
     # An electrolyser's hydrogen output is set by eAllEnergy2Hyd from its electricity
     # input, so its H2 second-block output variable is unused; fix it to zero. The
     # electrolyser's state logic uses commitment (on), standby and start-up (cold start);

--- a/src/el1xr_opt/Modules/oM_Investment.py
+++ b/src/el1xr_opt/Modules/oM_Investment.py
@@ -44,7 +44,10 @@ def create_investment(model, optmodel, indlog):
 
     # Always create the total investment-cost variable so the objective can use
     # it even when there are no candidate units.
-    setattr(optmodel, 'vTotalICost', Var(within=NonNegativeReals, doc='total annualized investment cost [MEUR]'))
+    # Audit C38: the unit label was [MEUR], but vTotalICost is added directly to the [EUR]
+    # operating-cost components in eTotalSCost (no unit conversion), so it must be in the same
+    # unit -- EUR (whatever native currency the data uses; the demo prints SEK). Label fixed.
+    setattr(optmodel, 'vTotalICost', Var(within=NonNegativeReals, doc='total annualized investment cost [EUR]'))
 
     if not len(model.egc) and not len(model.hgc):
         optmodel.vTotalICost.fix(0.0)
@@ -157,6 +160,12 @@ def create_investment(model, optmodel, indlog):
     # pEleGenInvestCost / pHydGenInvestCost are the annualized fixed cost of the
     # FULL nameplate unit (FixedInvestmentCost * FixedChargeRate), so with a build
     # fraction in [0,1] the cost of a partially built unit is the simple product.
+    # Asserted convention (audit C38): this factor1 multiplication is only dimensionally
+    # consistent because EVERY objective term (operating costs and this investment cost) is
+    # scaled by factor1, so factor1 acts as a single global objective scalar that does not
+    # change the argmin -- the build-vs-operate trade-off stays invariant under the unit
+    # choice. This holds at the shipped default factor1 == 1 (where it is a no-op); a
+    # factor1 != 1 regression test is the documented follow-up.
     #
     # Period weighting: operating costs enter the objective weighted by
     # pDiscountFactor[p] per period (eTotalTCost). The annualized investment cost

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -137,9 +137,15 @@ def create_objective_function_components(model, optmodel, indlog):
         return (optmodel.vTotalHydMCost[p,sc,n] == optmodel.vTotalHydMrkPPACost[p,sc,n])
     optmodel.__setattr__('eHydMarketCost', Constraint(optmodel.psn, rule=eHydMarketCost, doc='Total hydrogen market costs [kEUR]'))
 
+    # Audit C44: this rule defines the hydrogen day-ahead BUY cost. The constraint attribute
+    # is named to match its rule and the electricity analogue eEleMarketDayAheadCost (it was
+    # mis-registered as 'eTotalHydTradeCost'). The destination variable vTotalHydMrkPPACost
+    # holds this day-ahead trade cost -- the "PPA" in its name is historical (a separate
+    # hydrogen PPA term was never split out); the variable rename is deferred to avoid
+    # touching the objective registry and result-table column names.
     def eHydMarketDayAheadCost(optmodel, p,sc,n):
         return optmodel.vTotalHydMrkPPACost[p,sc,n] == sum(model.Par['pVarEnergyCost'][hr][p,sc,n] * optmodel.vHydBuy[p,sc,n,hr] for hr in model.hr)
-    optmodel.__setattr__('eTotalHydTradeCost', Constraint(optmodel.psn, rule=eHydMarketDayAheadCost, doc='Total hydrogen trade cost [kEUR]'))
+    optmodel.__setattr__('eHydMarketDayAheadCost', Constraint(optmodel.psn, rule=eHydMarketDayAheadCost, doc='Total hydrogen trade cost [kEUR]'))
 
     #%% Total hydrogen market revenues
     def eHydMarketRevenue(optmodel, p,sc,n):

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -351,6 +351,17 @@ def create_constraints(model, optmodel, indlog):
     # on, so existing cases build an identical constraint.
     community_on = bool(model.Par.get('pOptIndBinCommunity', 0))
 
+    # Audit C14 (analysed, NOT changed -- needs a modelling decision): this is the COMMERCIAL
+    # per-retailer balance (the retailer's assigned generation/demand/charge closed by
+    # vEleBuy/vEleSell). The PHYSICAL nodal balance with line flows and grid import/export is
+    # eEleBalance below. With a single retailer that owns the whole portfolio (every shipped
+    # case), this balance sums the entire system and the network flows are internal, so it is
+    # correct -- no flow term is needed and adding one would double-count the network already
+    # in eEleBalance. With two or more retailers split across nodes (no shipped case has this),
+    # the missing piece is the vEleBuy<->vEleImport coupling (the commented eEleBuyComposition
+    # below was the unfinished attempt), not a flow term here. Designing that multi-retailer
+    # commercial<->physical coupling, and any golden re-baseline it implies, is left as a
+    # deliberate decision; see docs/model_audit.md C14.
     def eEleRetNodeBalance(optmodel, p,sc,n,er):
         nd = model.Par['pEleRetNode'][er]
         if sum(1 for eg in eg2n[nd]) + sum(1 for egs in egs2n[nd]) + sum(1 for nf, cc in lout[nd]) + sum(1 for ni, cc in lin[nd]):

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -537,28 +537,28 @@ def create_constraints(model, optmodel, indlog):
 
     # The relation between the upward and downward bids and the provision of FCR-D reserves from an electric generator is defined as follows:
     def eEleRelationFreqDisUpBid2Gen(optmodel, p,sc,n,egt):
-        if model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egt] == 0:
+        if model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egt] == 0:
             return optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egt] == optmodel.vEleFreqContReserveDisUpGen[p,sc,n,egt]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqDisUpBid2Gen', Constraint(optmodel.psnegt, rule=eEleRelationFreqDisUpBid2Gen, doc='Relation FCR-D upward bid to generation'))
 
     def eEleRelationFreqDisDownBid2Gen(optmodel, p,sc,n,egt):
-        if model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egt] == 0:
+        if model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egt] == 0:
             return optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egt] == optmodel.vEleFreqContReserveDisDownGen[p,sc,n,egt]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqDisDownBid2Gen', Constraint(optmodel.psnegt, rule=eEleRelationFreqDisDownBid2Gen, doc='Relation FCR-D downward bid to generation'))
 
     def eEleRelationFreqNorUpBid2Gen(optmodel, p,sc,n,egt):
-        if model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egt] == 0:
+        if model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egt] == 0:
             return optmodel.vEleFreqContReserveNorBid[p,sc,n,egt] <= optmodel.vEleFreqContReserveNorUpGen[p,sc,n,egt]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqNorUpBid2Gen', Constraint(optmodel.psnegt, rule=eEleRelationFreqNorUpBid2Gen, doc='Relation FCR-N upward bid to generation'))
 
     def eEleRelationFreqNorDownBid2Gen(optmodel, p,sc,n,egt):
-        if model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egt] == 0:
+        if model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egt] == 0:
             return optmodel.vEleFreqContReserveNorBid[p,sc,n,egt] <= optmodel.vEleFreqContReserveNorDownGen[p,sc,n,egt]
         else:
             return Constraint.Skip
@@ -566,28 +566,28 @@ def create_constraints(model, optmodel, indlog):
 
     # The relation between the upward and downward bids and the provision of FCR-D reserves from an electric storage system is defined as follows:
     def eEleRelationFreqDisUpBid2Stor(optmodel, p,sc,n,egs):
-        if model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0:
+        if model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0:
             return optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs] == optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqDisUpBid2Stor', Constraint(optmodel.psnegs, rule=eEleRelationFreqDisUpBid2Stor, doc='Relation FCR-D upward bid to storage'))
 
     def eEleRelationFreqDisDownBid2Stor(optmodel, p,sc,n,egs):
-        if model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0:
+        if model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0:
             return optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs] == optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqDisDownBid2Stor', Constraint(optmodel.psnegs, rule=eEleRelationFreqDisDownBid2Stor, doc='Relation FCR-D downward bid to storage'))
 
     def eEleRelationFreqNorUpBid2Stor(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
             return optmodel.vEleFreqContReserveNorBid[p,sc,n,egs] == optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqNorUpBid2Stor', Constraint(optmodel.psnegs, rule=eEleRelationFreqNorUpBid2Stor, doc='Relation FCR-N upward bid to storage'))
 
     def eEleRelationFreqNorDownBid2Stor(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
             return optmodel.vEleFreqContReserveNorBid[p,sc,n,egs] == optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]
         else:
             return Constraint.Skip
@@ -595,14 +595,14 @@ def create_constraints(model, optmodel, indlog):
 
     # symmetrical FCR-N provision from an electric ESS
     def eEleSymmFreqNorStor2Ch(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pEleGenNoFCRN'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
             return optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs] == optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleSymmFreqNorStor2Ch', Constraint(optmodel.psnegs, rule=eEleSymmFreqNorStor2Ch, doc='Symmetrical FCR-N charge provision from storage'))
 
     def eEleSymmFreqNorStor2Dis(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pEleGenNoFCRN'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][egs] == 0):
             return optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs] == optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs]
         else:
             return Constraint.Skip
@@ -610,7 +610,7 @@ def create_constraints(model, optmodel, indlog):
 
     # The tight headroom bounds for FCR-D provision from an electric ESS is defined as follows:
     def eEleFreqUpDischargeHeadroom(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
             if  model.Par['pEleGenNoDayAhead'][egs] == 0 and model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
                 return optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs] <= model.Par['pEleMaxPower'][egs][p,sc,n] - optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs]
             else:
@@ -624,14 +624,14 @@ def create_constraints(model, optmodel, indlog):
     optmodel.__setattr__('eEleFreqUpDischargeHeadroom', Constraint(optmodel.psnegs, rule=eEleFreqUpDischargeHeadroom, doc='FCR-D and FCR-N upward discharge headroom'))
 
     def eEleFreqUpChargeHeadroom(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
             return optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs] <= optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqUpChargeHeadroom', Constraint(optmodel.psnegs, rule=eEleFreqUpChargeHeadroom, doc='FCR-D and FCR-N upward charge headroom'))
 
     def eEleFreqDownDischargeHeadroom(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
             if model.Par['pEleGenNoDayAhead'][egs] == 0 and model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
                 return optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs] <= optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs]
             else:
@@ -643,7 +643,7 @@ def create_constraints(model, optmodel, indlog):
     optmodel.__setattr__('eEleFreqDownDischargeHeadroom', Constraint(optmodel.psnegs, rule=eEleFreqDownDischargeHeadroom, doc='FCR-D downward discharge headroom'))
 
     def eEleFreqDownChargeHeadroom(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
             # For a candidate storage unit cap the down-charge reserve by the BUILT charge
             # capacity (nameplate * build fraction), so a fractionally built unit cannot
             # sell down-reserve on capacity it has not built (C21b).
@@ -655,14 +655,14 @@ def create_constraints(model, optmodel, indlog):
     optmodel.__setattr__('eEleFreqDownChargeHeadroom', Constraint(optmodel.psnegs, rule=eEleFreqDownChargeHeadroom, doc='FCR-D downward charge headroom'))
 
     def eEleFreqUpChargeBound(optmodel, p,sc,n,egs):
-        if ((model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0)) and model.Par['pEleMaxCharge'][egs][p,sc,n]:
+        if ((model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0)) and model.Par['pEleMaxCharge'][egs][p,sc,n]:
             return (optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= model.Par['pVarFixedAvailability'][egs][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqUpChargeBound', Constraint(optmodel.psnegs, rule=eEleFreqUpChargeBound, doc='FCR-D and FCR-N upward charge bound'))
 
     def eEleFreqUpDischargeBound(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
             if model.Par['pEleGenNoDayAhead'][egs] == 0 and model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
                 return (optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= model.Par['pVarFixedAvailability'][egs][p,sc,n]
             else:
@@ -672,14 +672,14 @@ def create_constraints(model, optmodel, indlog):
     optmodel.__setattr__('eEleFreqUpDischargeBound', Constraint(optmodel.psnegs, rule=eEleFreqUpDischargeBound, doc='FCR-D upward discharge bound'))
 
     def eEleFreqDownChargeBound(optmodel, p,sc,n,egs):
-        if ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0)) and model.Par['pEleMaxCharge'][egs][p,sc,n]:
+        if ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0)) and model.Par['pEleMaxCharge'][egs][p,sc,n]:
             return (optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= model.Par['pVarFixedAvailability'][egs][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqDownChargeBound', Constraint(optmodel.psnegs, rule=eEleFreqDownChargeBound, doc='FCR-D downward charge bound'))
 
     def eEleFreqDownDischargeBound(optmodel, p,sc,n,egs):
-        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRD'][egs] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and  model.Par['pEleGenNoFCRN'][egs] == 0):
             if model.Par['pEleGenNoDayAhead'][egs] == 0 and model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
                 return (optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= model.Par['pVarFixedAvailability'][egs][p,sc,n]
             else:
@@ -714,49 +714,49 @@ def create_constraints(model, optmodel, indlog):
     # (FCR-up = reduce, FCR-down = increase). There is no discharge side. Gated on the
     # electrolyser's own participation flags pHydGenNoFCRD / pHydGenNoFCRN (default 1).
     def eEleRelationFreqDisUpBid2Conv(optmodel, p,sc,n,e2h):
-        if model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0:
+        if model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0:
             return optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h] == optmodel.vEleFreqContReserveDisUpCha[p,sc,n,e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqDisUpBid2Conv', Constraint(optmodel.psne2h, rule=eEleRelationFreqDisUpBid2Conv, doc='Relation FCR-D upward bid to electrolyser consumption'))
 
     def eEleRelationFreqDisDownBid2Conv(optmodel, p,sc,n,e2h):
-        if model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0:
+        if model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0:
             return optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h] == optmodel.vEleFreqContReserveDisDownCha[p,sc,n,e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqDisDownBid2Conv', Constraint(optmodel.psne2h, rule=eEleRelationFreqDisDownBid2Conv, doc='Relation FCR-D downward bid to electrolyser consumption'))
 
     def eEleRelationFreqNorUpBid2Conv(optmodel, p,sc,n,e2h):
-        if model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0:
+        if model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0:
             return optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h] == optmodel.vEleFreqContReserveNorUpCha[p,sc,n,e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqNorUpBid2Conv', Constraint(optmodel.psne2h, rule=eEleRelationFreqNorUpBid2Conv, doc='Relation FCR-N upward bid to electrolyser consumption'))
 
     def eEleRelationFreqNorDownBid2Conv(optmodel, p,sc,n,e2h):
-        if model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0:
+        if model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0:
             return optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h] == optmodel.vEleFreqContReserveNorDownCha[p,sc,n,e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleRelationFreqNorDownBid2Conv', Constraint(optmodel.psne2h, rule=eEleRelationFreqNorDownBid2Conv, doc='Relation FCR-N downward bid to electrolyser consumption'))
 
     def eEleSymmFreqNorConv(optmodel, p,sc,n,e2h):
-        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 or model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0) and model.Par['pHydGenNoFCRN'][e2h] == 0:
+        if (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 or model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0) and model.Par['pHydGenNoFCRN'][e2h] == 0:
             return optmodel.vEleFreqContReserveNorUpCha[p,sc,n,e2h] == optmodel.vEleFreqContReserveNorDownCha[p,sc,n,e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleSymmFreqNorConv', Constraint(optmodel.psne2h, rule=eEleSymmFreqNorConv, doc='Symmetrical FCR-N provision from the electrolyser'))
 
     def eEleFreqUpChargeHeadroomConv(optmodel, p,sc,n,e2h):
-        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0):
             return optmodel.vEleFreqContReserveDisUpCha[p,sc,n,e2h] + optmodel.vEleFreqContReserveNorUpCha[p,sc,n,e2h] <= optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqUpChargeHeadroomConv', Constraint(optmodel.psne2h, rule=eEleFreqUpChargeHeadroomConv, doc='FCR upward charge headroom for the electrolyser'))
 
     def eEleFreqDownChargeHeadroomConv(optmodel, p,sc,n,e2h):
-        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0):
+        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0):
             return optmodel.vEleFreqContReserveDisDownCha[p,sc,n,e2h] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,e2h] <= model.Par['pHydMaxCharge2ndBlock'][e2h][p,sc,n] * optmodel.vHydGenCommitment[p,sc,n,e2h] - optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h]
         else:
             return Constraint.Skip
@@ -768,21 +768,21 @@ def create_constraints(model, optmodel, indlog):
     # because the headroom above already multiplies the nameplate by the commitment, and
     # multiplying by the build fraction too would be bilinear (C21b).
     def eEleFreqDownChargeHeadroomConvInvest(optmodel, p,sc,n,e2h):
-        if e2h in model.hgc and ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)):
+        if e2h in model.hgc and ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)):
             return optmodel.vEleFreqContReserveDisDownCha[p,sc,n,e2h] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,e2h] + optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h] <= model.Par['pHydMaxCharge2ndBlock'][e2h][p,sc,n] * optmodel.vHydGenInvest[e2h]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqDownChargeHeadroomConvInvest', Constraint(optmodel.psne2h, rule=eEleFreqDownChargeHeadroomConvInvest, doc='FCR downward charge headroom for a candidate electrolyser (build-limited)'))
 
     def eEleFreqUpChargeBoundConv(optmodel, p,sc,n,e2h):
-        if ((model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)) and model.Par['pHydMaxCharge'][e2h][p,sc,n]:
+        if ((model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)) and model.Par['pHydMaxCharge'][e2h][p,sc,n]:
             return (optmodel.vEleFreqContReserveDisUpCha[p,sc,n,e2h] + optmodel.vEleFreqContReserveNorUpCha[p,sc,n,e2h]) / model.Par['pHydMaxCharge'][e2h][p,sc,n] <= model.Par['pVarFixedAvailability'][e2h][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqUpChargeBoundConv', Constraint(optmodel.psne2h, rule=eEleFreqUpChargeBoundConv, doc='FCR upward charge bound for the electrolyser'))
 
     def eEleFreqDownChargeBoundConv(optmodel, p,sc,n,e2h):
-        if ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] >= 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)) and model.Par['pHydMaxCharge'][e2h][p,sc,n]:
+        if ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRD'][e2h] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pHydGenNoFCRN'][e2h] == 0)) and model.Par['pHydMaxCharge'][e2h][p,sc,n]:
             return (optmodel.vEleFreqContReserveDisDownCha[p,sc,n,e2h] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,e2h]) / model.Par['pHydMaxCharge'][e2h][p,sc,n] <= model.Par['pVarFixedAvailability'][e2h][p,sc,n]
         else:
             return Constraint.Skip
@@ -818,34 +818,37 @@ def create_constraints(model, optmodel, indlog):
         log_time('--- Declaring the frequency containment reserve (FCR-D and FCR-N) constraints:', StartTime, ind_log=indlog)
         StartTime = time.time() # to compute elapsed time
 
-    # Energy inflows of ESS (only for load levels multiple of 1, 24, 168, 8736 h depending on the ESS storage type) constrained by the ESS commitment decision times the inflows data [p.u.]
+    # Energy inflows of ESS (only for load levels multiple of 1, 24, 168, 8736 h depending on the ESS storage type) bounded by the inflows data parameter [p.u.].
+    # Note (audit C42): despite the "2Commitment" attribute name, the right-hand side is the
+    # parameter limit, not a commitment variable -- the commitment-coupled form was never wired.
+    # The name is kept to avoid renaming the constraint in result/.lp output; only the doc is corrected.
     def eEleMaxInflows2Commitment(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxStorage'][egs][p,sc,n] and model.Par['pEleMaxPower2ndBlock'][egs][p,sc,n] and model.Par['pEleMaxInflows'][egs][p,sc,n] and (n,egs) in model.negs:
             return optmodel.vEleEnergyInflows[p,sc,n,egs] / model.Par['pEleMaxInflows'][egs][p,sc,n] <= 1
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eEleMaxInflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMaxInflows2Commitment, doc='energy inflows to commitment [p.u.]'))
+    optmodel.__setattr__('eEleMaxInflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMaxInflows2Commitment, doc='energy inflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eEleMinInflows2Commitment(optmodel, p,sc,n,egs):
         if model.Par['pEleMinStorage'][egs][p,sc,n] and model.Par['pEleMaxPower2ndBlock'][egs][p,sc,n] and model.Par['pEleMinInflows'][egs][p,sc,n] and (n,egs) in model.negs:
             return optmodel.vEleEnergyInflows[p,sc,n,egs] / model.Par['pEleMinInflows'][egs][p,sc,n] >= 1
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eEleMinInflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMinInflows2Commitment, doc='energy inflows to commitment [p.u.]'))
+    optmodel.__setattr__('eEleMinInflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMinInflows2Commitment, doc='energy inflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eHydMaxInflows2Commitment(optmodel, p,sc,n,hgs):
         if model.Par['pHydMaxStorage'][hgs][p,sc,n] and model.Par['pHydMaxPower2ndBlock'][hgs][p,sc,n] and model.Par['pHydMaxInflows'][hgs][p,sc,n] and (n,hgs) in model.nhgs:
             return optmodel.vHydEnergyInflows[p,sc,n,hgs] / model.Par['pHydMaxInflows'][hgs][p,sc,n] <= 1
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eHydMaxInflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMaxInflows2Commitment, doc='energy inflows to commitment [p.u.]'))
+    optmodel.__setattr__('eHydMaxInflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMaxInflows2Commitment, doc='energy inflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eHydMinInflows2Commitment(optmodel, p,sc,n,hgs):
         if model.Par['pHydMinStorage'][hgs][p,sc,n] and model.Par['pHydMaxPower2ndBlock'][hgs][p,sc,n] and model.Par['pHydMinInflows'][hgs][p,sc,n] and (n,hgs) in model.nhgs:
             return optmodel.vHydEnergyInflows[p,sc,n,hgs] / model.Par['pHydMinInflows'][hgs][p,sc,n] >= 1
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eHydMinInflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMinInflows2Commitment, doc='energy inflows to commitment [p.u.]'))
+    optmodel.__setattr__('eHydMinInflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMinInflows2Commitment, doc='energy inflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     # print if the constraints object len is greater than 0
     if len(optmodel.eEleMaxInflows2Commitment) > 0 or len(optmodel.eEleMinInflows2Commitment) > 0 or len(optmodel.eHydMaxInflows2Commitment) > 0 or len(optmodel.eHydMinInflows2Commitment) > 0:
@@ -1057,34 +1060,36 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
     optmodel.__setattr__('eAllEnergy2Ele', Constraint(optmodel.psnh2e, rule=eAllEnergy2Ele, doc='energy conversion from different energy type to electricity [p.u.]'))
 
-    # ESS outflows (only for load levels multiple of 1, 24, 168, 672, and 8736 h depending on the ESS outflow cycle) must be satisfied [GWh]
+    # ESS outflows (only for load levels multiple of 1, 24, 168, 672, and 8736 h depending on the ESS outflow cycle) bounded by the outflows data parameter [p.u.].
+    # Note (audit C42): the "2Commitment" attribute name is a misnomer -- the right-hand side
+    # is the parameter limit, not a commitment variable. Name kept; only the doc is corrected.
     def eEleMaxOutflows2Commitment(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxCharge'][egs][p,sc,n] and model.Par['pEleMaxPower2ndBlock'][egs][p,sc,n] and model.Par['pEleMaxOutflows'][egs][p,sc,n] and (n,egs) in model.negs:
             return optmodel.vEleEnergyOutflows[p,sc,n,egs] / model.Par['pEleMaxOutflows'][egs][p,sc,n] <= 1.0
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eEleMaxOutflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMaxOutflows2Commitment, doc='energy outflows to commitment [p.u.]'))
+    optmodel.__setattr__('eEleMaxOutflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMaxOutflows2Commitment, doc='energy outflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eEleMinOutflows2Commitment(optmodel, p,sc,n,egs):
         if model.Par['pEleMinCharge'][egs][p,sc,n] and model.Par['pEleMaxPower2ndBlock'][egs][p,sc,n] and model.Par['pEleMinOutflows'][egs][p,sc,n] and (n,egs) in model.negs:
             return optmodel.vEleEnergyOutflows[p,sc,n,egs] / model.Par['pEleMinOutflows'][egs][p,sc,n] >= 1.0
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eEleMinOutflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMinOutflows2Commitment, doc='energy outflows to commitment [p.u.]'))
+    optmodel.__setattr__('eEleMinOutflows2Commitment', Constraint(optmodel.psnegs, rule=eEleMinOutflows2Commitment, doc='energy outflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eHydMaxOutflows2Commitment(optmodel, p,sc,n,hgs):
         if model.Par['pHydMaxCharge'][hgs][p,sc,n] and model.Par['pHydMaxPower2ndBlock'][hgs][p,sc,n] and model.Par['pHydMaxOutflows'][hgs][p,sc,n] and (n,hgs) in model.nhgs:
             return optmodel.vHydEnergyOutflows[p,sc,n,hgs] / model.Par['pHydMaxOutflows'][hgs][p,sc,n] <= 1.0
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eHydMaxOutflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMaxOutflows2Commitment, doc='energy outflows to commitment [p.u.]'))
+    optmodel.__setattr__('eHydMaxOutflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMaxOutflows2Commitment, doc='energy outflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eHydMinOutflows2Commitment(optmodel, p,sc,n,hgs):
         if model.Par['pHydMinCharge'][hgs][p,sc,n] and model.Par['pHydMaxPower2ndBlock'][hgs][p,sc,n] and model.Par['pHydMinOutflows'][hgs][p,sc,n] and (n,hgs) in model.nhgs:
             return optmodel.vHydEnergyOutflows[p,sc,n,hgs] / model.Par['pHydMinOutflows'][hgs][p,sc,n] >= 1.0
         else:
             return Constraint.Skip
-    optmodel.__setattr__('eHydMinOutflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMinOutflows2Commitment, doc='energy outflows to commitment [p.u.]'))
+    optmodel.__setattr__('eHydMinOutflows2Commitment', Constraint(optmodel.psnhgs, rule=eHydMinOutflows2Commitment, doc='energy outflows bound [p.u.] (parameter limit, not commitment; audit C42)'))
 
     def eEleMaxEnergyOutflows(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxCharge'][egs][p,sc,n] + model.Par['pEleMaxPower'][egs][p,sc,n] and (n,egs) in model.negso:
@@ -1161,7 +1166,7 @@ def create_constraints(model, optmodel, indlog):
     def eEleMaxESSOutput2ndBlock(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
             # return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= 1.0
-            if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and (model.Par['pEleGenNoDayAhead'][egs] == 1 or model.Par['pEleGenNoDayAhead'][egs] == 0):
+            if model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0:
                 return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= 1.0
             else:
                 return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= optmodel.vEleStorDischarge[p,sc,n,egs]
@@ -1174,7 +1179,7 @@ def create_constraints(model, optmodel, indlog):
     def eEleMinESSOutput2ndBlock(optmodel, p,sc,n,egs):
         if model.Par['pEleMinPower'][egs][p,sc,n]:
             # return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] - optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs]) / model.Par['pEleMinPower'][egs][p,sc,n] >= 0.0
-            if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and (model.Par['pEleGenNoDayAhead'][egs] == 1 or model.Par['pEleGenNoDayAhead'][egs] == 0):
+            if model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0:
                 return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] - optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] - optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs]) / model.Par['pEleMinPower'][egs][p,sc,n] >= 0.0
             else:
                 return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] - optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egs] - optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egs]) / model.Par['pEleMinPower'][egs][p,sc,n] >= optmodel.vEleStorDischarge[p,sc,n,egs]
@@ -1204,7 +1209,7 @@ def create_constraints(model, optmodel, indlog):
     def eEleMaxESSCharge2ndBlock(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxCharge'][egs][p,sc,n]:
             # return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= 1.0
-            if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and (model.Par['pEleGenNoDayAhead'][egs] == 1 or model.Par['pEleGenNoDayAhead'][egs] == 0):
+            if model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0:
                 return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= 1.0
             else:
                 return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= optmodel.vEleStorCharge[p,sc,n,egs]
@@ -1215,7 +1220,7 @@ def create_constraints(model, optmodel, indlog):
     def eEleMinESSCharge2ndBlock(optmodel, p,sc,n,egs):
         if model.Par['pEleMinCharge'][egs][p,sc,n]:
             # return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] - optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs]) / model.Par['pEleMinCharge'][egs][p,sc,n] >= 0.0
-            if  (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and (model.Par['pEleGenNoDayAhead'][egs] == 1 or model.Par['pEleGenNoDayAhead'][egs] == 0):
+            if  model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0:
                 return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] - optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs] - optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs]) / model.Par['pEleMinCharge'][egs][p,sc,n] >= 0.0
             else:
                 return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] - optmodel.vEleFreqContReserveDisUpCha[p,sc,n,egs] - optmodel.vEleFreqContReserveNorUpCha[p,sc,n,egs]) / model.Par['pEleMinCharge'][egs][p,sc,n] >= optmodel.vEleStorCharge[p,sc,n,egs]
@@ -1232,6 +1237,11 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
     optmodel.__setattr__('eE2HMaxCharge2ndBlock', Constraint(optmodel.psne2h, rule=eE2HMaxCharge2ndBlock, doc='max charge of an ESS [p.u.]'))
 
+    # Standard min-2nd-block symmetry constraint (audit C28): with a NonNegative 2nd
+    # block and a right-hand side of commitment-1 in {-1, 0}, this row is non-binding by
+    # construction, exactly like eHydMinESSOutput2ndBlock / eHydMinOutput2ndBlock. The
+    # state chain is enforced by eE2HMaxCharge2ndBlock; this is kept for structural
+    # symmetry with the electricity ESS, not to bind.
     def eE2HMinCharge2ndBlock(optmodel, p,sc,n,e2h):
         if model.Par['pHydMaxCharge2ndBlock'][e2h][p,sc,n]:
             return optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h] / model.Par['pHydMaxCharge2ndBlock'][e2h][p,sc,n] >= optmodel.vHydGenCommitment[p,sc,n,e2h] - 1

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -24,7 +24,7 @@ def create_objective_function(model, optmodel, indlog):
     # defining the objective function
     def eTotalSCost(optmodel):
         return optmodel.vTotalSCost
-    optmodel.__setattr__('eTotalSCost', Objective(rule=eTotalSCost, sense=minimize, doc='Total system cost [kEUR]'))
+    optmodel.__setattr__('eTotalSCost', Objective(rule=eTotalSCost, sense=minimize, doc='Total system cost [EUR]'))
 
     def eTotalTCost(optmodel):
         # vTotalICost is the investment cost from the capacity-sizing layer

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -536,7 +536,7 @@ def create_constraints(model, optmodel, indlog):
 
     def eEleFreqContReserveNor(optmodel, p,sc,n):
         if sum(1 for egt in model.egt if model.Par['pEleGenNoFCRN'][egt] == 0) + sum(1 for egs in model.egs if model.Par['pEleGenNoFCRN'][egs] == 0) + sum(1 for e2h in model.e2h if model.Par['pHydGenNoFCRN'][e2h] == 0):
-            return sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRN'][egt] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRN'][egs] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRN'][e2h] == 0) <= (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] + model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n]) / 2
+            return sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRN'][egt] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRN'][egs] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRN'][e2h] == 0) <= min(model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n], model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n])
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqContReserveNor', Constraint(optmodel.psn, rule=eEleFreqContReserveNor, doc='Frequency containment reserve - normal'))
@@ -715,6 +715,24 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
     optmodel.__setattr__('eEleStorageEnduranceDown', Constraint(optmodel.psnegs, rule=eEleStorageEnduranceDown, doc='Storage endurance for FCR-D and FCR-N downward'))
 
+    # C30: the two rolling endurance constraints above back the bid at n-1 with the inventory
+    # at n and skip the first level, so the bid at the LAST level has no energy backing. Add a
+    # terminal row that backs the last level's bid with the last level's inventory (the
+    # inventory one period ahead does not exist), so end-of-horizon bids are not free.
+    def eEleStorageEnduranceUpEnd(optmodel, p,sc,n,egs):
+        if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and model.Par['pEleMaxStorage'][egs][p,sc,n] and n == model.n.last():
+            return optmodel.vEleInventory[p,sc,n,egs] >= (1/model.Par['pEleGenEfficiency_discharge'][egs]) * ((model.Par['pEleGenEnduranceFCRD'][egs]/60) * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs] + (model.Par['pEleGenEnduranceFCRN'][egs]/60) * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs])
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleStorageEnduranceUpEnd', Constraint(optmodel.psnegs, rule=eEleStorageEnduranceUpEnd, doc='Storage endurance for the terminal-level FCR-D/N upward bid (C30)'))
+
+    def eEleStorageEnduranceDownEnd(optmodel, p,sc,n,egs):
+        if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and model.Par['pEleMaxStorage'][egs][p,sc,n] and n == model.n.last():
+            return model.Par['pEleMaxStorage'][egs][p,sc,n] - optmodel.vEleInventory[p,sc,n,egs] >= model.Par['pEleGenEfficiency_charge'][egs] * ((model.Par['pEleGenEnduranceFCRD'][egs]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs] + (model.Par['pEleGenEnduranceFCRN'][egs]/60) * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs])
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleStorageEnduranceDownEnd', Constraint(optmodel.psnegs, rule=eEleStorageEnduranceDownEnd, doc='Storage endurance for the terminal-level FCR-D/N downward bid (C30)'))
+
     # --- Electrolyser (e2h) FCR provision: charge-side mirror of the storage formulation.
     # An electrolyser is a controllable load, so it offers FCR by modulating consumption
     # (FCR-up = reduce, FCR-down = increase). There is no discharge side. Gated on the
@@ -812,6 +830,22 @@ def create_constraints(model, optmodel, indlog):
         rhs = sum(model.Par['pHydMaxStorage'][hgs][p,sc,n] - optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
         return lhs <= rhs
     optmodel.__setattr__('eEleFreqDownEnduranceConv', Constraint(optmodel.psnnd, rule=eEleFreqDownEnduranceConv, doc='Electrolyser FCR-down endurance bounded by node hydrogen-store headroom'))
+
+    # C30: the rolling conv-endurance above backs the bid at n-1 with the store headroom at n
+    # and skips the first level, leaving the last level's bid unbacked. Back it with the
+    # terminal-level store headroom (mirrors eEleStorageEnduranceDownEnd for the e2h node).
+    def eEleFreqDownEnduranceConvEnd(optmodel, p,sc,n,nd):
+        if n != model.n.last():
+            return Constraint.Skip
+        e2h_at_node = [e2h for e2h in model.e2h if (nd,e2h) in model.n2hg and (model.Par['pHydGenNoFCRD'][e2h] == 0 or model.Par['pHydGenNoFCRN'][e2h] == 0)]
+        hgs_at_node = [hgs for hgs in model.hgs if (nd,hgs) in model.n2hg]
+        if not e2h_at_node:
+            return Constraint.Skip
+        lhs = sum(((model.Par['pHydGenEnduranceFCRD'][e2h]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]
+                 + (model.Par['pHydGenEnduranceFCRN'][e2h]/60) * optmodel.vEleFreqContReserveNorBid       [p,sc,n,e2h]) / model.Par['pHydGenProductionFunction'][e2h] for e2h in e2h_at_node)
+        rhs = sum(model.Par['pHydMaxStorage'][hgs][p,sc,n] - optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
+        return lhs <= rhs
+    optmodel.__setattr__('eEleFreqDownEnduranceConvEnd', Constraint(optmodel.psnnd, rule=eEleFreqDownEnduranceConvEnd, doc='Electrolyser FCR-down endurance for the terminal load level (C30)'))
 
     # print if the constraints object len is greater than 0
     if (len(optmodel.eEleFreqContReserveDisUpward) > 0 or len(optmodel.eEleFreqContReserveDisDownward) > 0 or
@@ -1467,7 +1501,7 @@ def create_constraints(model, optmodel, indlog):
     def eEleMaxRampUpOutput(optmodel, p,sc,n,egt):
         if model.Par['pEleGenRampUp'][egt] and model.Par['pOptIndBinGenRamps'] == 1 and model.Par['pEleGenRampUp'][egt] < model.Par['pEleMaxPower2ndBlock'][egt][p,sc,n]:
             if n == model.n.first():
-                return (- max(model.Par['pEleSystemOutput'] - model.Par['pEleMinPower'][egt][p,sc,n],0.0)                                               + optmodel.vEleTotalOutput2ndBlock[p,sc,n,egt] + optmodel.vEleFreqContReserveDisUpGen[p,sc,n,egt]) / model.Par['pDuration'][p,sc,n] / model.Par['pEleGenRampUp'][egt] <=   optmodel.vEleGenCommitment[p,sc,n,egt] - optmodel.vEleGenStartUp[p,sc,n,egt]
+                return (- max(model.Par['pEleInitialOutput'][p,sc,egt] - model.Par['pEleMinPower'][egt][p,sc,n],0.0)                                               + optmodel.vEleTotalOutput2ndBlock[p,sc,n,egt] + optmodel.vEleFreqContReserveDisUpGen[p,sc,n,egt]) / model.Par['pDuration'][p,sc,n] / model.Par['pEleGenRampUp'][egt] <=   optmodel.vEleGenCommitment[p,sc,n,egt] - optmodel.vEleGenStartUp[p,sc,n,egt]
             else:
                 return (- optmodel.vEleTotalOutput2ndBlock[p,sc,model.n.prev(n),egt] - optmodel.vEleFreqContReserveDisDownGen[p,sc,model.n.prev(n),egt] + optmodel.vEleTotalOutput2ndBlock[p,sc,n,egt] + optmodel.vEleFreqContReserveDisUpGen[p,sc,n,egt]) / model.Par['pDuration'][p,sc,n] / model.Par['pEleGenRampUp'][egt] <=   optmodel.vEleGenCommitment[p,sc,n,egt] - optmodel.vEleGenStartUp[p,sc,n,egt]
         else:
@@ -1477,7 +1511,7 @@ def create_constraints(model, optmodel, indlog):
     def eEleMaxRampDwOutput(optmodel, p,sc,n,egt):
         if model.Par['pEleGenRampDown'][egt] and model.Par['pOptIndBinGenRamps'] == 1 and model.Par['pEleGenRampDown'][egt] < model.Par['pEleMaxPower2ndBlock'][egt][p,sc,n]:
             if n == model.n.first():
-                return (- max(model.Par['pEleSystemOutput'] - model.Par['pEleMinPower'][egt][p,sc,n],0.0)                                             + optmodel.vEleTotalOutput2ndBlock[p,sc,n,egt] + optmodel.vEleFreqContReserveDisDownGen[p,sc,n,egt]) / model.Par['pDuration'][p,sc,n] / model.Par['pEleGenRampDown'][egt] >= - model.Par['pEleInitialUC'][p,sc,egt]                 + optmodel.vEleGenShutDown[p,sc,n,egt]
+                return (- max(model.Par['pEleInitialOutput'][p,sc,egt] - model.Par['pEleMinPower'][egt][p,sc,n],0.0)                                             + optmodel.vEleTotalOutput2ndBlock[p,sc,n,egt] + optmodel.vEleFreqContReserveDisDownGen[p,sc,n,egt]) / model.Par['pDuration'][p,sc,n] / model.Par['pEleGenRampDown'][egt] >= - model.Par['pEleInitialUC'][p,sc,egt]                 + optmodel.vEleGenShutDown[p,sc,n,egt]
             else:
                 return (- optmodel.vEleTotalOutput2ndBlock[p,sc,model.n.prev(n),egt] - optmodel.vEleFreqContReserveDisUpGen[p,sc,model.n.prev(n),egt] + optmodel.vEleTotalOutput2ndBlock[p,sc,n,egt] + optmodel.vEleFreqContReserveDisDownGen[p,sc,n,egt]) / model.Par['pDuration'][p,sc,n] / model.Par['pEleGenRampDown'][egt] >= - optmodel.vEleGenCommitment[p,sc,model.n.prev(n),egt] + optmodel.vEleGenShutDown[p,sc,n,egt]
         else:
@@ -1562,6 +1596,13 @@ def create_constraints(model, optmodel, indlog):
         StartTime = time.time() # to compute elapsed time
 
     # maximum ramp up and ramp down for the charge of an H2 ESS [p.u.]
+    # Audit C37: these charge/outflow ramps reuse the generation ramp parameter
+    # pHydGenRampUp/Down because no dedicated hydrogen outflow-ramp parameter exists in the
+    # input schema (the electricity side defines pEleGenOutflowsRampUp/Down but leaves the
+    # matching constraint commented out, so electricity storage currently has no outflow
+    # ramp at all). The physical charge/outflow ramp of an H2 store can differ from its
+    # generation ramp; adding a dedicated pHydGenOutflowsRamp* parameter (with a fallback to
+    # the generation ramp, keeping existing cases unchanged) is the documented follow-up.
     def eHydMaxRampUpCharge(optmodel, p,sc,n,hgs):
         if model.Par['pHydGenRampUp'][hgs] > 0 and model.Par['pOptIndBinGenRamps'] == 1:
             if n == model.n.first():

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -990,3 +990,57 @@ def test_hydrogen_peak_indicators_on_hydrogen_sets(h2_model):
         assert rets <= hr, \
             f"{vname} is indexed by {sorted(rets - hr)} -- not hydrogen retailers"
         assert not (rets & (er - hr)), f"{vname} carries electricity retailers"
+
+
+# --- 2026-06 audit batch 1: dead / vacuous logic cleanup --------------------
+# C28 eE2HMinCharge2ndBlock vacuous (documented, non-binding by design);
+# C29 reserve-require gates flipped >=0 -> >0; C32 RES FCR bid vars fixed to 0;
+# C42 misleading "2Commitment" docs corrected; C45 tautological NoDayAhead conjunct removed.
+
+
+def test_reserve_require_gates_use_strict_positive():
+    """C29: the per-unit FCR build gates tested ``pOperatingReserveRequire_* >= 0``,
+    always true for a fillna(0), clamped parameter, so they built dead rows at zero-
+    requirement levels. They must test ``> 0`` so a zero requirement skips the row (the
+    requirement cap still binds the bids to zero)."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    import re
+    bad = re.findall(r"pOperatingReserveRequire_[A-Za-z_]+'\]\[p,sc,n\]\s*>=\s*0", text)
+    assert not bad, f"reserve-require gates still use '>= 0' (C29): {bad[:3]}"
+    good = re.findall(r"pOperatingReserveRequire_[A-Za-z_]+'\]\[p,sc,n\]\s*>\s*0", text)
+    assert len(good) >= 20, f"expected the reserve-require gates to use '> 0' (C29), found {len(good)}"
+
+
+def test_res_fcr_bid_variables_are_fixed(h2_model):
+    """C32: RES generators (egr) carry FCR bid variables (declared over eg) but appear in
+    no cap, relation, or revenue term. They must be fixed to zero so they cannot carry
+    arbitrary values into the result tables."""
+    m = h2_model
+    assert len(m.egr) > 0, "fixture has no RES generator"
+    p, sc = list(m.ps)[0]
+    n = list(m.n)[0]
+    egr = list(m.egr)[0]
+    for vname in ("vEleFreqContReserveDisUpwardBid", "vEleFreqContReserveDisDownwardBid",
+                  "vEleFreqContReserveNorBid"):
+        v = getattr(m, vname)[p, sc, n, egr]
+        assert v.fixed and v.value == 0.0, \
+            f"{vname}[{egr}] must be fixed to 0 for a RES unit (C32)"
+
+
+def test_no_tautological_nodayahead_conjunct():
+    """C45: the ESS 2nd-block bounds gated on
+    ``(pEleGenNoDayAhead == 1 or pEleGenNoDayAhead == 0)`` -- a binary, so always true --
+    making the binary-gated branch unreachable. The dead conjunct is removed (behaviour is
+    unchanged; mutual exclusion still holds via the charge/discharge decisions)."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    assert "pEleGenNoDayAhead'][egs] == 1 or model.Par['pEleGenNoDayAhead'][egs] == 0" not in text, \
+        "the always-true NoDayAhead conjunct must be removed (C45)"
+
+
+def test_inflow_outflow_bound_docs_not_commitment():
+    """C42: the eEle/eHyd Max/Min In/Outflows2Commitment constraints bound the in/outflow
+    variable by a parameter limit -- there is no commitment variable. The misleading
+    'to commitment' doc string is corrected (the attribute name is retained on purpose)."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    assert "to commitment [p.u.]" not in text, \
+        "the misleading 'to commitment' doc must be corrected (C42)"

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1072,3 +1072,61 @@ def test_hydrogen_day_ahead_constraint_name_matches_rule(h2_model):
         "hydrogen day-ahead cost constraint must be named eHydMarketDayAheadCost (C44)"
     assert not hasattr(m, "eTotalHydTradeCost"), \
         "the misattributed name eTotalHydTradeCost must be gone (C44)"
+    # the electricity analogue it now mirrors
+    assert hasattr(m, "eEleMarketDayAheadCost")
+
+
+# --- 2026-06 audit batch 3: parameter correctness --------------------------
+# C30 terminal-level endurance backing; C31 FCR-N cap uses min not avg;
+# C37 H2 storage ramp reuse documented; C46 per-unit pre-horizon ramp output.
+
+
+def test_first_step_ramp_uses_per_unit_initial_output():
+    """C46: the first-step thermal ramp used the scalar system aggregate pEleSystemOutput
+    (overwritten across (p,sc), so only the last scenario survived) as every unit's
+    pre-horizon output. It must use the unit's own pEleInitialOutput[p,sc,egt]."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    # within the two first-step ramp branches, the system aggregate must be gone
+    for rule in ("eEleMaxRampUpOutput", "eEleMaxRampDwOutput"):
+        start = text.index(f"def {rule}(")
+        body = text[start:text.index(f"rule={rule}", start)]
+        assert "pEleSystemOutput" not in body, f"{rule} must not use the system aggregate (C46)"
+        assert "pEleInitialOutput'][p,sc,egt]" in body, \
+            f"{rule} must use the per-unit pre-horizon output (C46)"
+
+
+def test_fcrn_volume_cap_uses_minimum_not_average():
+    """C31: the FCR-N volume cap (a symmetric product) must bound the bids by the MINIMUM of
+    the up/down requirements, not their average. The price average (FCR-N revenue) is a
+    separate, legitimate term and is left untouched."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    start = text.index("def eEleFreqContReserveNor(")
+    body = text[start:text.index("rule=eEleFreqContReserveNor", start)]
+    assert "min(model.Par['pOperatingReserveRequire_FCRN_Up']" in body, \
+        "FCR-N volume cap must use min(up, down) (C31)"
+    assert "Require_FCRN_Down'][p,sc,n]) / 2" not in body, \
+        "FCR-N volume cap must not use the average (C31)"
+
+
+def test_terminal_endurance_constraints_exist(green_model):
+    """C30: the rolling endurance constraints leave the last load level's FCR bid unbacked.
+    Terminal-level endurance constraints must exist so end-of-horizon bids are energy-backed.
+    On ElectrolyserFCR the e2h node-level terminal constraint is built with active rows."""
+    m = green_model
+    for name in ("eEleStorageEnduranceUpEnd", "eEleStorageEnduranceDownEnd",
+                 "eEleFreqDownEnduranceConvEnd"):
+        assert hasattr(m, name), f"terminal endurance constraint {name} missing (C30)"
+    assert len(m.eEleFreqDownEnduranceConvEnd) > 0, \
+        "the e2h terminal endurance has no active rows on ElectrolyserFCR (C30)"
+    # the terminal rows reference the LAST load level
+    last = m.n.last()
+    assert any(idx[2] == last for idx in m.eEleFreqDownEnduranceConvEnd), \
+        "terminal endurance must bind the last load level (C30)"
+
+
+def test_h2_storage_ramp_reuse_is_documented():
+    """C37: the hydrogen storage charge/outflow ramp reuses the generation ramp parameter;
+    this is documented as a known data-schema limitation with a dedicated-parameter follow-up."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    assert "Audit C37" in text and "pHydGenOutflowsRamp" in text, \
+        "the C37 ramp-reuse limitation must be documented at the H2 charge ramp"

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1130,3 +1130,19 @@ def test_h2_storage_ramp_reuse_is_documented():
     text = open(MODEL_FORMULATION, encoding="utf-8").read()
     assert "Audit C37" in text and "pHydGenOutflowsRamp" in text, \
         "the C37 ramp-reuse limitation must be documented at the H2 charge ramp"
+
+
+# --- 2026-06 audit batch 4: investment dimensional convention --------------
+
+
+def test_investment_cost_unit_label_consistent():
+    """C38: vTotalICost is added directly to the [EUR] operating-cost components in
+    eTotalSCost, so its unit must be EUR -- the [MEUR] label was wrong. The factor1 scaling
+    is documented as a global-objective-scalar convention (valid because every objective term
+    is scaled by factor1)."""
+    inv = open(INVESTMENT, encoding="utf-8").read()
+    assert "investment cost [EUR]" in inv, "vTotalICost must be labelled [EUR] (C38)"
+    assert "investment cost [MEUR]" not in inv, "the wrong [MEUR] label must be gone (C38)"
+    assert "Asserted convention (audit C38)" in inv, "the factor1 convention must be documented (C38)"
+    obj = open(MODEL_FORMULATION, encoding="utf-8").read()
+    assert "Total system cost [EUR]" in obj, "the objective unit label must be [EUR] to match (C38)"

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1044,3 +1044,31 @@ def test_inflow_outflow_bound_docs_not_commitment():
     text = open(MODEL_FORMULATION, encoding="utf-8").read()
     assert "to commitment [p.u.]" not in text, \
         "the misleading 'to commitment' doc must be corrected (C42)"
+
+
+# --- 2026-06 audit batch 2: load-time warnings & relabels -------------------
+# C34 peak cost is a constant offset at zero peaks; C35 standby needs binary UC;
+# C36 ignored electrolyser shut-down cost; C39 dropped future-dated unit;
+# C44 misattributed hydrogen day-ahead constraint name.
+
+
+def test_batch2_warnings_present():
+    """C34/C35/C36/C39: each is a byte-safe load-time warning (no model change). Guard that
+    the warning and its triggering condition are wired in oM_InputData."""
+    text = open(INPUT_DATA, encoding="utf-8").read()
+    assert "WARNING (C34)" in text and "pParNumberPowerPeaks'] == 0" in text, "C34 warning missing"
+    assert "WARNING (C35)" in text and "pOptIndBinGenOperat'] == 0" in text, "C35 warning missing"
+    assert "WARNING (C36)" in text and "pHydGenShutDownCost'][e2h] > 0" in text, "C36 warning missing"
+    assert "WARNING (C39)" in text and "InitialPeriod'][_g] > _base_year" in text, "C39 warning missing"
+
+
+def test_hydrogen_day_ahead_constraint_name_matches_rule(h2_model):
+    """C44: the hydrogen day-ahead buy cost constraint was registered as
+    ``eTotalHydTradeCost`` while its rule is ``eHydMarketDayAheadCost`` -- a name-grep
+    mismatch. The attribute is now named after its rule, mirroring the electricity analogue
+    ``eEleMarketDayAheadCost``."""
+    m = h2_model
+    assert hasattr(m, "eHydMarketDayAheadCost"), \
+        "hydrogen day-ahead cost constraint must be named eHydMarketDayAheadCost (C44)"
+    assert not hasattr(m, "eTotalHydTradeCost"), \
+        "the misattributed name eTotalHydTradeCost must be gone (C44)"

--- a/tests/test_heat_sector.py
+++ b/tests/test_heat_sector.py
@@ -215,3 +215,62 @@ def test_heat_case_runs_through_build_model():
     assert hns < 1e-4 and abs(served - total_demand) < 1e-3
     # the heat pump drew electricity (the cross-sector coupling fired)
     assert sum(value(m.vHeatPumpElec[p, sc, n, "HP1"]) for n in m.n) > 1e-3
+
+
+# --- 2026-06 audit C40: heat sector hardening ------------------------------
+
+
+@pytest.mark.solve
+def test_heat_store_terminal_and_not_served_cap():
+    """C40: the thermal store must keep a terminal condition (final inventory >= initial, so
+    the starting stock is not free energy) and heat-not-served must be capped by demand."""
+    m = _build()
+    assert hasattr(m, "eHeatInventoryTerminal") and len(m.eHeatInventoryTerminal) > 0
+    assert hasattr(m, "eHeatNotServedCap") and len(m.eHeatNotServedCap) > 0
+    SolverFactory("appsi_highs").solve(m)
+    initial = m.Par["pHeatStoInitial"]["TS"]
+    final = value(m.vHeatInventory[P, S, LEVELS[-1], "TS"])
+    assert final >= initial - 1e-6, f"final inventory {final} below initial {initial} (C40)"
+    # not-served never exceeds the demand it stands for
+    for n in LEVELS:
+        assert value(m.vHeatNotServed[P, S, n, "HD"]) <= DEMAND[n] + 1e-6
+
+
+@pytest.mark.solve
+def test_heat_store_only_node_enters_balance():
+    """C40: a node carrying only a thermal store (no demand/generation) must appear in the
+    heat balance, so the store's charge/discharge is constrained instead of free."""
+    m = ConcreteModel()
+    m.n = Set(initialize=LEVELS, ordered=True)
+    m.ps = [(P, S)]
+    m.htd = ["HD"]; m.htg = ["BOIL"]; m.htp = []; m.htw = []; m.hts = ["TS"]
+    m.n2htd = [("H", "HD")]; m.n2htg = [("H", "BOIL")]; m.n2htw = []
+    m.n2hts = [("STO", "TS")]                          # store on its OWN node
+    m.Par = {
+        "pHeatDemand": {"HD": _psn(DEMAND)}, "pHeatGenMaxPower": {"BOIL": 100.0},
+        "pHeatGenCost": {"BOIL": 1.0}, "pHeatPumpCOP": {},
+        "pHeatStoMax": {"TS": 20.0}, "pHeatStoEff": {"TS": 0.95}, "pHeatStoInitial": {"TS": 0.0},
+        "pHeatNSCost": 1000.0, "pDuration": {n: 1.0 for n in LEVELS},
+    }
+    create_heat_sector(m, m)
+    store_node_rows = [idx for idx in m.eHeatBalance if idx[-1] == "STO"]
+    assert store_node_rows, "the store-only node 'STO' is missing from the heat balance (C40)"
+
+
+@pytest.mark.solve
+def test_power_heat_power_loop_warns(capsys):
+    """C40: warn when COP x heat-to-power efficiency >= 1 (a free power loop -> unbounded LP)."""
+    m = ConcreteModel()
+    m.n = Set(initialize=LEVELS, ordered=True)
+    m.ps = [(P, S)]
+    m.htd = ["HD"]; m.htg = ["HP"]; m.htp = ["HP"]; m.htw = ["ORC"]; m.hts = []
+    m.n2htd = [("H", "HD")]; m.n2htg = [("H", "HP")]; m.n2htw = [("H", "ORC")]; m.n2hts = []
+    m.Par = {
+        "pHeatDemand": {"HD": _psn(DEMAND)}, "pHeatGenMaxPower": {"HP": 30.0},
+        "pHeatGenCost": {"HP": 0.0}, "pHeatPumpCOP": {"HP": 3.0},      # COP 3 x eff 0.4 = 1.2 >= 1
+        "pHeatToEleMaxHeat": {"ORC": 80.0}, "pHeatToEleEff": {"ORC": 0.4},
+        "pHeatStoMax": {}, "pHeatStoEff": {}, "pHeatStoInitial": {},
+        "pHeatNSCost": 1000.0, "pDuration": {n: 1.0 for n in LEVELS},
+    }
+    create_heat_sector(m, m)
+    assert "WARNING (C40)" in capsys.readouterr().out, "free power-heat-power loop must warn (C40)"

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -115,14 +115,21 @@ SIZING_CASES = [
     # FCR-active battery goldens re-baselined for C21b/C18: a candidate battery can no
     # longer sell FCR-down reserve on unbuilt capacity, so it earns slightly less reserve
     # revenue and the net cost rises a little. HomeBattNoFCR is unchanged (no FCR).
+    # Re-baselined again for audit C30: the FCR endurance constraints left the LAST load
+    # level's bid with no energy backing, so a unit could over-bid reserve at end of horizon
+    # for free. Backing the terminal bid removes that spurious revenue, so the four cases that
+    # exploited it (HoodBatt, HomeBattFCRNonly, H2Tank, Electrolyser) cost a little more; the
+    # others were not bidding at the last level and are unchanged. (C31 min-vs-avg and C46
+    # per-unit ramp are latent here: the FCR-N up/down requirements are equal and these cases
+    # have no thermal ramp units.)
     pytest.param("HomeBatt",          44.27655530263448, id="HomeBatt"),
-    pytest.param("HoodBatt",         -22.04188316124317, id="HoodBatt"),
+    pytest.param("HoodBatt",         -19.98879641148733, id="HoodBatt"),
     pytest.param("HomeBattNoTariff", 125.5265553026345,  id="HomeBattNoTariff"),
     pytest.param("HomeBattNoFCR",    122.8894702739726,  id="HomeBattNoFCR"),
     pytest.param("HomeBattFCRDonly",  67.90928111201895, id="HomeBattFCRDonly"),
-    pytest.param("HomeBattFCRNonly",  56.98016352651909, id="HomeBattFCRNonly"),
-    pytest.param("H2Tank",            6774.093295025795, id="H2Tank"),
-    pytest.param("Electrolyser",      6774.089825257397, id="Electrolyser"),
+    pytest.param("HomeBattFCRNonly",  57.34981288056188, id="HomeBattFCRNonly"),
+    pytest.param("H2Tank",            6776.719863855105, id="H2Tank"),
+    pytest.param("Electrolyser",      6776.716428518055, id="Electrolyser"),
 ]
 SIZING_CASE_NAMES = ["HomeBatt", "HoodBatt", "HomeBattNoTariff", "HomeBattNoFCR",
                      "HomeBattFCRDonly", "HomeBattFCRNonly", "H2Tank", "Electrolyser",


### PR DESCRIPTION
Addresses the remaining open findings in docs/model_audit.md across 6 batches (one commit each). 13 code-fixed, C28/C37/C40-power-rating documented as intentional, C38 unit-label fix, C14 analysed and flagged for a modelling decision. Only golden change: C30 re-baselines 4 sizing goldens upward (free end-of-horizon FCR bid removed). Full solve tier 54 passed / 1 skipped.