### PR TITLE
Couple retail buy/sell to grid import/export at the reference node (C14)

### DIFF
--- a/docs/model_audit.md
+++ b/docs/model_audit.md
@@ -390,25 +390,26 @@ incident lines in its build guard but includes no flow/import/export term, so in
 multi-node case the retailer must cover the local imbalance as if the network
 delivered nothing (the commented-out `eEleBuyComposition` suggests the buy-import
 link was never finished). Correct only for single-node cases.
-**— ANALYSED, NOT CHANGED (batch 6): needs a modelling decision, flagged for the user.**
-The model carries two parallel balances: the PHYSICAL nodal balance `eEleBalance` (KCL with
-`vEleNetFlow` and grid `vEleImport`/`vEleExport`; grid fees/taxes/incentives are charged on
-`vEleImport`/`vEleExport`), and this COMMERCIAL per-retailer balance (the retailer's assigned
-generation/demand/charge closed by `vEleBuy`/`vEleSell`; the energy/day-ahead cost is charged
-on `vEleBuy`). Verified that EVERY shipped/sizing case has exactly ONE retailer (`EleR_01`)
-owning the entire portfolio (no unassigned generation or demand), so this balance sums the
-whole system and the network flows are internal to that single portfolio -- it is **correct
-as-is** for all goldens, which is why they pass. C14 only bites with **two or more retailers
-split across nodes** (no shipped case has this). The genuine missing piece is then NOT a flow
-term here (the flows are already in `eEleBalance`; adding them here would double-count) but the
-unfinished `vEleBuy` <-> `vEleImport` coupling that ties each retailer's commercial purchase to
-the physical grid import at its node. Designing that multi-retailer commercial/physical
-coupling is a real modelling task whose only effect is on multi-retailer multi-node cases, and
-it would re-baseline goldens on a chosen semantics. Rather than guess that semantics and risk
-baking an incorrect balance into the validated multi-node goldens, the code is left unchanged
-with a clarifying comment at the constraint; the design is flagged for the user. **Decision
-needed:** is the retail balance intended as a commercial portfolio balance (current behaviour,
-keep) or a true nodal balance, and how should `vEleBuy` couple to `vEleImport` per retailer?
+**— DONE (decision taken: finish the buy<->import coupling).** The model carries two parallel
+balances: the PHYSICAL nodal balance `eEleBalance` (KCL with `vEleNetFlow` and grid
+`vEleImport`/`vEleExport`; grid fees/taxes/incentives are charged on `vEleImport`/`vEleExport`),
+and the COMMERCIAL per-retailer balance `eEleRetNodeBalance` (the retailer's assigned
+generation/demand/charge closed by `vEleBuy`/`vEleSell`; the day-ahead energy cost is charged on
+`vEleBuy`). The two were never tied together -- the energy-cost base (`vEleBuy`) and the
+grid-fee base (`vEleImport`) could in principle diverge. The fix finishes the old
+`eEleBuyComposition` stub as two constraints at the electricity reference node:
+`eEleImportBuyLink` (`vEleImport == sum_er vEleBuy`) and `eEleExportSellLink`
+(`vEleExport == sum_er vEleSell`). All external trade crosses the reference node (import/export
+are fixed to zero elsewhere in network mode), so the grid import equals the total retail buy and
+the grid export equals the total retail sell -- one or more retailers. For a single retailer that
+owns the whole portfolio (every shipped case) cost minimisation already drives `vEleBuy` to the
+net grid draw, so the coupling is non-binding and **all goldens are byte-unchanged** (the solve
+is also faster, the extra equalities tighten the LP). Verified on the multi-node Grid1 (retailer
+at the reference node, assets on other nodes over lines): `import == buy` and `export == sell`
+exactly. Guarded by `test_retail_buy_couples_to_grid_import`. **Note:** this couples retail trade
+to the grid at the *reference node*. A retailer sitting at a non-reference node (no shipped case)
+would still need per-node settlement -- the full nodal multi-retailer redesign -- which remains
+future work.
 
 C15. **Duration weighting is inconsistent for several money terms.** (a) The
 volumetric grid fee (`eTotalEleNetUseVarCost`, :79), energy tax (:146) and incentive

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -351,17 +351,11 @@ def create_constraints(model, optmodel, indlog):
     # on, so existing cases build an identical constraint.
     community_on = bool(model.Par.get('pOptIndBinCommunity', 0))
 
-    # Audit C14 (analysed, NOT changed -- needs a modelling decision): this is the COMMERCIAL
-    # per-retailer balance (the retailer's assigned generation/demand/charge closed by
-    # vEleBuy/vEleSell). The PHYSICAL nodal balance with line flows and grid import/export is
-    # eEleBalance below. With a single retailer that owns the whole portfolio (every shipped
-    # case), this balance sums the entire system and the network flows are internal, so it is
-    # correct -- no flow term is needed and adding one would double-count the network already
-    # in eEleBalance. With two or more retailers split across nodes (no shipped case has this),
-    # the missing piece is the vEleBuy<->vEleImport coupling (the commented eEleBuyComposition
-    # below was the unfinished attempt), not a flow term here. Designing that multi-retailer
-    # commercial<->physical coupling, and any golden re-baseline it implies, is left as a
-    # deliberate decision; see docs/model_audit.md C14.
+    # Audit C14: this is the COMMERCIAL per-retailer balance (the retailer's assigned
+    # generation/demand/charge closed by vEleBuy/vEleSell). The PHYSICAL nodal balance with
+    # line flows and grid import/export is eEleBalance below. The two layers are tied together
+    # by eEleImportBuyLink / eEleExportSellLink (below), which couple the retail buy/sell to the
+    # grid import/export at the electricity reference node; see docs/model_audit.md C14.
     def eEleRetNodeBalance(optmodel, p,sc,n,er):
         nd = model.Par['pEleRetNode'][er]
         if sum(1 for eg in eg2n[nd]) + sum(1 for egs in egs2n[nd]) + sum(1 for nf, cc in lout[nd]) + sum(1 for ni, cc in lin[nd]):
@@ -381,12 +375,29 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
     optmodel.__setattr__('eEleRetMaxBuy', Constraint(optmodel.psner, rule=eEleRetMaxBuy, doc='Maximum electricity buys [kWh]'))
 
-    # def eEleBuyComposition(optmodel, p,sc,n,er):
-    #     if model.Par['pEleRetMaxBuy'][er] > 0:
-    #         return optmodel.vEleBuy[p,sc,n,er] == sum(optmodel.vEleDemand[p,sc,n,ed] for ed in model.ed if (er,ed) in model.r2ed) + sum(optmodel.vEleTotalCharge[p,sc,n,egs] for egs in model.egs if (er,egs) in model.r2eg)
-    #     else:
-    #         return Constraint.Skip
-    # optmodel.__setattr__('eEleBuyComposition', Constraint(optmodel.psner, rule=eEleBuyComposition, doc='Electricity buy composition [kWh]'))
+    # Audit C14: couple the commercial layer (vEleBuy/vEleSell, which carry the day-ahead
+    # energy cost) to the physical layer (vEleImport/vEleExport at the reference node, which
+    # carry the grid-transfer fee and energy tax). All external trade crosses the electricity
+    # reference node -- import/export are fixed to zero at every other node in network mode --
+    # so the grid import equals the sum of every retailer's buy and the grid export equals the
+    # sum of every retailer's sell. This is the finished form of the old eEleBuyComposition
+    # stub: it makes the energy-cost base and the grid-fee base the same physical quantity and
+    # is correct for one or more retailers. (For a single retailer that owns the whole portfolio
+    # the retail and physical balances already drive buy to the net grid draw, so this is
+    # non-binding there; it becomes load-bearing once multiple retailers transact at the grid.)
+    def eEleImportBuyLink(optmodel, p,sc,n,nd):
+        if nd in model.endrf and len(model.er) > 0:
+            return optmodel.vEleImport[p,sc,n,nd] == sum(optmodel.vEleBuy[p,sc,n,er] for er in model.er)
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleImportBuyLink', Constraint(optmodel.psnnd, rule=eEleImportBuyLink, doc='Couple grid import to retail buy at the reference node (C14) [kW]'))
+
+    def eEleExportSellLink(optmodel, p,sc,n,nd):
+        if nd in model.endrf and len(model.er) > 0:
+            return optmodel.vEleExport[p,sc,n,nd] == sum(optmodel.vEleSell[p,sc,n,er] for er in model.er)
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleExportSellLink', Constraint(optmodel.psnnd, rule=eEleExportSellLink, doc='Couple grid export to retail sell at the reference node (C14) [kW]'))
 
     # Maximum electricity sells
     def eEleRetMaxSell(optmodel, p,sc,n,er):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -98,6 +98,29 @@ def test_cost_from_duckdb(label, d, case, expected, rtol, tmp_path):
     _assert_cost(float(pyo.value(model.eTotalSCost)), expected, rtol)
 
 
+@pytest.mark.solve
+def test_retail_buy_couples_to_grid_import():
+    """C14: the commercial retail buy/sell must equal the physical grid import/export at the
+    electricity reference node (eEleImportBuyLink / eEleExportSellLink), so the energy cost and
+    the grid-transfer fee are charged on the same flow. Checked on the multi-node Grid1 case,
+    where the retailer sits at the reference node and the assets are on other nodes reached
+    over lines -- the case that would expose a retail balance that ignored the network."""
+    d = os.path.join(REPO, "src", "el1xr_opt")
+    with truncated_duration(d, "Grid1"):
+        m = routine(**_run_dict(d, "Grid1"))
+    assert m is not None
+    assert len(m.eEleImportBuyLink) > 0 and len(m.eEleExportSellLink) > 0, \
+        "C14 buy<->import coupling constraints were not built"
+    p, sc = list(m.ps)[0]
+    ref = list(m.endrf)
+    imp = sum(m.vEleImport[p, sc, n, nd]() for n in m.n for nd in ref)
+    buy = sum(m.vEleBuy[p, sc, n, er]() for n in m.n for er in m.er)
+    exp = sum(m.vEleExport[p, sc, n, nd]() for n in m.n for nd in ref)
+    sell = sum(m.vEleSell[p, sc, n, er]() for n in m.n for er in m.er)
+    assert abs(imp - buy) < 1e-4, f"grid import {imp} != retail buy {buy} (C14)"
+    assert abs(exp - sell) < 1e-4, f"grid export {exp} != retail sell {sell} (C14)"
+
+
 # --- Sizing / tariff / frequency-market variant cases ------------------------
 # These are small LP cases generated from the H2VPP base by
 # data/sizing/make_sizing_cases.py and read as .duckdb input files. The fixture


### PR DESCRIPTION
Finishes the C14 retail/physical coupling: adds eEleImportBuyLink and eEleExportSellLink at the electricity reference node, tying the day-ahead energy-cost base (vEleBuy) to the grid-fee base (vEleImport). Non-binding for the single-retailer shipped cases — all goldens byte-unchanged (solve tier 21 passed); verified on multi-node Grid1 that import==buy and export==sell. A retailer at a non-reference node would still need per-node settlement (future work).