### PR TITLE
fix: scale per-step retail buy/sell caps by factor1; confirm peak-tar…

### DIFF
--- a/docs/factor1_electrolyser_dev_plan.md
+++ b/docs/factor1_electrolyser_dev_plan.md
@@ -100,11 +100,34 @@ factor1 -- energy, FCR, O&M, CO2, fuel, grid fee, energy tax, incentive, Paslag,
 fixed charges + investment lump sum + dimensionless ratios unscaled). factor1 is now settable via
 the FACTOR1 module global (default 1.0).
 VERIFIED: factor1=1 is BYTE-UNCHANGED (21 solve goldens + 54 fast tests pass -> no regression).
-factor1 INVARIANCE is EXACT for the continuous model: Home1 with the peak tariff disabled gives
-identical total cost at factor1=1 and factor1=2 (ratio 1.00000). Guarded by test_factor1_invariant.
-RESIDUAL (documented follow-up): the peak-demand power-tariff is a MILP (binary peak-hour
-selection) whose discrete structure does not scale cleanly with factor1, so peak-tariff cases are
-not exactly invariant. The _adjusted_import constant addend is now scaled by factor1 (a kW
-constant). Making the peak-selection MILP scale-invariant is the remaining factor1 item.
-STILL TODO: factor2 elimination + the PWL part-load-efficiency feature + degradation cost (Phase B,
-not started); the peak-tariff MILP invariance.
+factor1 INVARIANCE is EXACT for the continuous model AND the peak-demand tariff MILP.
+
+PEAK-TARIFF MILP — RESOLVED (was a stale "residual"). Re-measuring on the merged code shows the
+peak tariff IS scale-invariant: Home1 and Grid1 with the peak tariff ENABLED give identical total
+cost at factor1=1 and factor1=2 (Grid1 bit-for-bit, reldiff 0.0; peak cost component invariant in
+every case). The earlier 0.856 non-invariance was an intermediate broken state (before the
+energy-price double-scaling fix and the _adjusted_import addend fix), not a property of the
+peak-selection MILP -- the selected peak hours are unchanged under a uniform rescaling and
+tariff/factor1 x peak-quantity*factor1 is invariant. test_factor1_invariant now runs Home1 with the
+peak tariff ON (no longer disabled).
+
+MAXBUY/MAXSELL — FIXED (audit C38, this branch). The per-step retail caps pEleRetMaxBuy/MaxSell
+(constraints eEleRetMaxBuy/eEleRetMaxSell) are per-step power quantities (kW/step) but were read
+unscaled (not in idx_retail_factoring) -- a sell pinned at the cap earned half the revenue at twice
+the unit scale. Now scaled by factor1 in oM_InputData (a zero "no cap" stays zero). This makes the
+day-ahead market revenue (vTotalEleMrkDARev) exactly invariant (was ratio 0.5). factor1=1 is x1, so
+goldens are byte-unchanged.
+
+REMAINING factor1 RESIDUAL (separate from the peak tariff): the FCR-provision sizing cases
+(HomeBattNoTariff, HomeBattFCRDonly) are still not exactly invariant. The FCR PRICES (/factor1) and
+requirement caps (*factor1) scale correctly and the UPWARD FCR-D bid scales exactly x2, but the
+DOWNWARD FCR-D bid from storage is sub-proportional (~x1.86) and the battery dispatch differs
+qualitatively between scales (charge/inventory profiles not proportional). The cost genuinely
+differs (ratio ~1.16, not equal-cost degeneracy), so a storage FCR-D headroom / SoC-coupling
+interaction binds sub-proportionally. The dimensional audit of those constraints (headroom bounds,
+SoC endurance lines ~743-768) shows them clean, so the next step is to trace which binding actually
+limits the downward bid at factor1=2 (candidate: interaction of the day-ahead charge schedule with
+the down-charge headroom MaxCharge - charge2ndBlock). This is a distinct, harder item.
+
+STILL TODO: the FCR-D storage downward-provision invariance (above); factor2 elimination + the PWL
+part-load-efficiency feature + degradation cost (Phase B, not started).

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -235,11 +235,19 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     # eRetMaxBuy/Sell constraints (they skip a zero cap). The hydrogen retail file
     # has no MaxBuy/MaxSell columns, so activating a hydrogen retailer would
     # otherwise KeyError here; the electricity file already carries them.
+    # factor1 (audit C38): MaxBuy/MaxSell are per-step power caps (kW/step) -- extensive
+    # quantities -- so they must scale by factor1 like the other quantity bounds (the var ub
+    # pEleRetMaximumEnergySell already does). Without this the cap stays fixed while prices
+    # carry 1/factor1, so a sell pinned at the cap earns half the revenue at twice the unit
+    # scale, breaking invariance. They are read unscaled by _update_parameters (not in
+    # idx_retail_factoring), so scale them here. A defaulted/zero cap (= "no cap") stays zero.
     for sector, df_key in [('Ele', 'dfElectricityRetail'), ('Hyd', 'dfHydrogenRetail')]:
         for cap in ['MaxBuy', 'MaxSell']:
             key = f'p{sector}Ret{cap}'
             if key not in parameters_dict:
                 parameters_dict[key] = pd.Series(0.0, index=data_frames[df_key].index)
+            else:
+                parameters_dict[key] = parameters_dict[key] * factor1
         # TariffType is optional too (the hydrogen retail file does not carry it).
         # Default to '' = no peak tariff: the variable-fixing loops compare against
         # 'Hourly'/'Daily' and fix every peak variable of any other type to zero.

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1158,21 +1158,16 @@ def test_factor1_default_is_one(h2_model):
 def test_factor1_invariant():
     """C38: factor1 is a TRUE unit conversion -- it scales extensive quantities by factor1 and
     per-quantity prices by 1/factor1, leaving fixed charges / investment / ratios unscaled, so
-    the optimum (total cost) is INVARIANT. Verified on Home1 with the peak-demand tariff disabled
-    (the discrete peak-tariff MILP does not scale cleanly; that residual is a documented
-    follow-up). Solving at FACTOR1=1 and FACTOR1=2 must give the same total system cost."""
+    the optimum (total cost) is INVARIANT. Verified on Home1 with the peak-demand tariff ENABLED:
+    the discrete peak-tariff MILP is scale-invariant too (the selected peak hours are unchanged
+    under a uniform unit rescaling, and tariff/factor1 x peak-quantity*factor1 is invariant), so
+    no peak component is excluded. Solving at FACTOR1=1 and FACTOR1=2 must give the same total
+    system cost."""
     import el1xr_opt.Modules.oM_InputData as _ID
     src = os.path.join(REPO, "src", "el1xr_opt", "Home1")
     work = tempfile.mkdtemp(prefix="f1inv_")
     dst = os.path.join(work, "Home1")
     shutil.copytree(src, dst)
-    # disable the peak-demand tariff (its MILP selection is not factor1-invariant -- separate WIP)
-    par = os.path.join(dst, "oM_Data_Parameter_Home1.csv")
-    pf = pd.read_csv(par)
-    for c in pf.columns:
-        if "NumberPowerPeaks" in c:
-            pf[c] = 0
-    pf.to_csv(par, index=False)
     # truncate to one week so the solve is fast
     dur = os.path.join(dst, "oM_Data_Duration_Home1.csv")
     dd = pd.read_csv(dur, index_col=[0, 1, 2])


### PR DESCRIPTION
…iff invariance

  (audit C38)

The peak-demand tariff MILP is already scale-invariant on the merged code (Home1/Grid1 with   peaks give identical cost at factor1=1 vs 2, Grid1 bit-for-bit); the earlier non-invariance was a stale intermediate-state measurement, so no peak fix was needed. test_factor1_invariant now runs
Home1 with the peak tariff ENABLED (peak-disabling removed) to guard this.
Real bug found while verifying: pEleRetMaxBuy/pEleRetMaxSell are per-step power caps (kW/step) but were read unscaled (not in idx_retail_factoring), so a sell pinned at the cap earned half the revenue at twice the unit scale (day-ahead revenue ratio 0.5). Now scaled by factor1 (a zero 'no cap' stays zero); day-ahead market revenue is exactly invariant. factor1=1 is x1, so goldens are byte-unchanged (21 solve goldens + 54 fast tests pass).

Remaining factor1 residual (separate, documented): the FCR-provision sizing cases are still non-invariant due to sub-proportional downward FCR-D storage provision -- a distinct follow-up.