### PR TITLE
feat: flag-gated piecewise-linear electrolyser part-load efficiency (…

### DIFF
--- a/docs/factor1_electrolyser_dev_plan.md
+++ b/docs/factor1_electrolyser_dev_plan.md
@@ -61,6 +61,26 @@ ShutDownCost to realistic canonical-currency values (see B2). Re-baseline e2h go
 B1. Piecewise-linear part-load efficiency (replace the constant ProductionFunction = 56.82
 kWh/kgH2). FLAG-GATED: default = constant (legacy/non-e2h cases byte-unchanged); PWL when a flag
 (e.g. dfOption IndPWLEfficiency, or a per-unit segmented-curve column) is set.
+
+B1 STATUS — DONE (branch feature/phase-b-pwl-efficiency).
+- Flag: dfOption IndBinElectrolyserPWL (catalogue feature electrolyser_pwl_efficiency in
+  oM_Features; default 0 -> constant ProductionFunction, all existing goldens byte-unchanged).
+- Curve: built in oM_InputData.create_variables (model.pwl_curve / model.hpwl). 4 breakpoints per
+  flagged e2h unit spanning [MinCharge, MaxCharge] (productive electricity x, hydrogen y). Specific
+  energy = full-load ProductionFunction x a canonical alkaline multiplier m(f) (Brauns & Turek
+  shape, anchors f=[0.10,0.20,0.50,0.85,1.00] -> m=[1.35,1.25,1.08,0.97,1.00]); at full load m=1 so
+  the PWL reproduces the legacy linear conversion exactly. No new data files (derived from existing
+  params); B2/later can swap in per-unit measured curves.
+- Formulation (oM_ModelFormulation): SOS2 convex combination. appsi/HiGHS has NO native SOS2
+  (verified: "Highs interface does not support SOS constraints"), so SOS2 is encoded with segment
+  binaries (adjacency). Rows: ePWLConvexity (sum weights == commitment), ePWLSegmentSum (one active
+  segment == commitment), ePWLAdjacency (weight_k <= adjacent segments), ePWLPower (productive
+  electricity = sum weight_k x_k), ePWLHydrogen (H2 = sum weight_k y_k). eAllEnergy2Hyd skips PWL
+  units. Off/standby (commitment 0) -> all weights 0 -> no power, no H2. Segment domain follows the
+  commitment (Binary, or relaxed under pOptIndBinGenOperat==0 = convex-hull relaxation).
+- Test: test_electrolyser_pwl_efficiency (patches ElectrolyserStandby duckdb Option to flag on;
+  asserts PWL active, linear skipped, curve reproduces PF at full load + varies, SOS2 holds in the
+  solution). Default-off byte-unchanged confirmed (full solve + fast tiers pass).
 - Anchors (Brauns & Turek 2020, alkaline): best efficiency ~80-90% load; specific energy
   ~50-56 kWh/kgH2 at full load rising to ~62-73 kWh/kgH2 at 20% load; min stable load ~10-20%
   (already represented by MinimumCharge). PEM: worse at part load, min load ~5%.

--- a/src/el1xr_opt/Modules/oM_Features.py
+++ b/src/el1xr_opt/Modules/oM_Features.py
@@ -64,6 +64,8 @@ FEATURES = [
     Feature("energy_community",       "IndBinCommunity",     0, makes_integer=False,
             module="oM_Community",
             doc="energy-community / virtual sharing among members in a zone"),
+    Feature("electrolyser_pwl_efficiency", "IndBinElectrolyserPWL", 0, makes_integer=True,
+            doc="piecewise-linear electrolyser part-load efficiency (else constant ProductionFunction)"),
 ]
 
 FLAG_DEFAULTS = {f.flag: f.default for f in FEATURES}

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1031,6 +1031,37 @@ def create_variables(model, optmodel, indlog):
     #%% start time
     StartTime = time.time()
 
+    # %% Electrolyser piecewise-linear part-load efficiency curve (audit Phase B / B1)
+    # Replaces the constant ProductionFunction (kWh/kgH2) with a part-load curve. FLAG-GATED
+    # by pOptIndBinElectrolyserPWL (default 0 -> constant ProductionFunction, byte-unchanged).
+    # Canonical alkaline shape (Brauns & Turek 2020, Processes 8(2):248): specific energy is
+    # lowest near ~85% load and rises toward both low load and full load. The multipliers are
+    # RELATIVE to the unit's full-load ProductionFunction, so at full load the PWL reproduces
+    # the legacy linear conversion exactly. Each curve is 4 breakpoints (x_k = productive
+    # electricity in kW, y_k = hydrogen out in kgH2/h) spanning the unit's [MinCharge, MaxCharge]
+    # productive range; the SOS2 (segment-binary) convex combination in oM_ModelFormulation
+    # picks the active segment.
+    model.pwl_curve = {}
+    model.hpwl      = []
+    model.pwlbp     = list(range(4))   # breakpoint indices 0..3
+    model.pwlseg    = list(range(3))   # segment indices 0..2 (between adjacent breakpoints)
+    if int(model.Par.get('pOptIndBinElectrolyserPWL', 0)) == 1:
+        _anchor_f    = [0.10, 0.20, 0.50, 0.85, 1.00]   # load fraction
+        _anchor_mult = [1.35, 1.25, 1.08, 0.97, 1.00]   # specific energy / full-load value
+        for g in model.e2h:
+            pf   = float(model.Par['pHydGenProductionFunction'][g])
+            pmax = max(float(model.Par['pHydMaxCharge'][g][idx]) for idx in model.psn)
+            try:
+                pmin = max(float(model.Par['pHydMinCharge'][g][idx]) for idx in model.psn)
+            except (KeyError, ValueError):
+                pmin = 0.0
+            if pf <= 0.0 or pmax <= 0.0:
+                continue
+            fmin  = max(min(pmin / pmax, 1.0), 0.0)
+            fracs = [fmin + (1.0 - fmin) * t for t in (0.0, 0.4, 0.75, 1.0)]
+            model.pwl_curve[g] = [(f * pmax, (f * pmax) / (pf * float(np.interp(f, _anchor_f, _anchor_mult)))) for f in fracs]
+            model.hpwl.append(g)
+
     # model.Peaks   = Set(initialize=[ i for i in range(1,4,1)]) # number of selected peaks hours
     if model.Par['pParNumberPowerPeaks'] == 0:
         model.Peaks   = RangeSet(1)
@@ -1223,6 +1254,18 @@ def create_variables(model, optmodel, indlog):
         setattr(optmodel, 'vHydPeakGlobalInd',             Var(model.psnhr, model.Peaks, within=Binary,       initialize=0, doc='peak hour indicator                   '))
         setattr(optmodel, 'vHydPeakMonthInd',              Var(model.psdhr, model.Peaks, within=Binary,       initialize=0, doc='monthly peak hour indicator           '))
         setattr(optmodel, 'vHydPeakDayInd',                Var(model.psdnhr,             within=Binary,       initialize=0, doc='daily peak hour indicator             '))
+
+    # Electrolyser PWL part-load efficiency (audit Phase B / B1): breakpoint weights (lambda)
+    # and the active-segment indicator for the SOS2 convex combination. Built only for the
+    # flagged electrolysers (model.hpwl), so default-off cases declare nothing (byte-unchanged).
+    # The segment indicator follows the commitment's domain (binary, or relaxed under the LP
+    # operation mode); the weights are always continuous in [0,1] (bounded by the convexity row).
+    if model.hpwl:
+        _pwl_seg_domain = UnitInterval if model.Par['pOptIndBinGenOperat'] == 0 else Binary
+        _pwl_bp_idx  = [(p, sc, n, g, k) for (p, sc, n) in model.psn for g in model.hpwl for k in model.pwlbp]
+        _pwl_seg_idx = [(p, sc, n, g, s) for (p, sc, n) in model.psn for g in model.hpwl for s in model.pwlseg]
+        setattr(optmodel, 'vHydGenPWLWeight',  Var(_pwl_bp_idx,  within=NonNegativeReals, initialize=0, doc='electrolyser PWL breakpoint weight (lambda)'))
+        setattr(optmodel, 'vHydGenPWLSegment', Var(_pwl_seg_idx, within=_pwl_seg_domain,  initialize=0, doc='electrolyser PWL active-segment indicator'))
 
     if model.Par['pOptIndBinNetOperat'] == 0:
         setattr(optmodel, 'vEleNetCommit',                 Var(model.psnela,  within=UnitInterval, initialize=0, doc='network binary operation              '))

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -1068,8 +1068,11 @@ def create_constraints(model, optmodel, indlog):
         StartTime = time.time() # to compute elapsed time
 
     # Energy conversion from energy from electricity to hydrogen and vice versa [p.u.]
+    # A PWL-flagged electrolyser (e2h in model.hpwl) uses the piecewise-linear part-load
+    # curve below instead of this constant-efficiency conversion, so it is skipped here.
+    _hpwl = getattr(model, 'hpwl', [])
     def eAllEnergy2Hyd(optmodel, p,sc,n,e2h):
-        if model.Par['pHydMaxPower'][e2h][p,sc,n] and e2h in model.e2h:
+        if model.Par['pHydMaxPower'][e2h][p,sc,n] and e2h in model.e2h and e2h not in _hpwl:
             # Only the productive consumption makes hydrogen; the standby draw
             # (StandByPower while in the standby state) produces none, so it is
             # subtracted before converting electricity input to hydrogen output.
@@ -1077,6 +1080,42 @@ def create_constraints(model, optmodel, indlog):
         else:
             return Constraint.Skip
     optmodel.__setattr__('eAllEnergy2Hyd', Constraint(optmodel.psne2h, rule=eAllEnergy2Hyd, doc='energy conversion from different energy type to hydrogen [p.u.]'))
+
+    # Piecewise-linear electrolyser part-load efficiency (audit Phase B / B1). Replaces the
+    # constant-efficiency conversion above for the flagged electrolysers (model.hpwl) with a
+    # SOS2 convex combination over the (productive electricity, hydrogen) breakpoints in
+    # model.pwl_curve. appsi/HiGHS has no native SOS2, so the SOS2 condition is encoded with
+    # segment binaries (adjacency): the weights may be nonzero only on the two breakpoints of a
+    # single active segment, giving an exact piecewise-linear conversion. The convexity and
+    # segment-sum rows equal the commitment, so an off or standby unit (commitment = 0) has all
+    # weights zero -> zero productive power and zero hydrogen, while an on unit sits on the curve
+    # between MinCharge and MaxCharge. The productive electricity excludes the standby draw,
+    # matching the constant-efficiency form.
+    if _hpwl:
+        psn_hpwl = [(p, sc, n, g) for (p, sc, n) in model.psn for g in _hpwl]
+
+        def ePWLConvexity(optmodel, p,sc,n,g):
+            return sum(optmodel.vHydGenPWLWeight[p,sc,n,g,k] for k in model.pwlbp) == optmodel.vHydGenCommitment[p,sc,n,g]
+        optmodel.__setattr__('ePWLConvexity', Constraint(psn_hpwl, rule=ePWLConvexity, doc='electrolyser PWL weights sum to the on-state'))
+
+        def ePWLSegmentSum(optmodel, p,sc,n,g):
+            return sum(optmodel.vHydGenPWLSegment[p,sc,n,g,s] for s in model.pwlseg) == optmodel.vHydGenCommitment[p,sc,n,g]
+        optmodel.__setattr__('ePWLSegmentSum', Constraint(psn_hpwl, rule=ePWLSegmentSum, doc='electrolyser PWL exactly one active segment when on'))
+
+        psn_hpwl_bp = [(p, sc, n, g, k) for (p, sc, n) in model.psn for g in _hpwl for k in model.pwlbp]
+        def ePWLAdjacency(optmodel, p,sc,n,g,k):
+            # weight on breakpoint k is allowed only if an adjacent segment (k-1 or k) is active
+            segs = [s for s in (k - 1, k) if s in model.pwlseg]
+            return optmodel.vHydGenPWLWeight[p,sc,n,g,k] <= sum(optmodel.vHydGenPWLSegment[p,sc,n,g,s] for s in segs)
+        optmodel.__setattr__('ePWLAdjacency', Constraint(psn_hpwl_bp, rule=ePWLAdjacency, doc='electrolyser PWL SOS2 adjacency (weights only on the active segment)'))
+
+        def ePWLPower(optmodel, p,sc,n,g):
+            return optmodel.vEleTotalCharge[p,sc,n,g] - model.Par['pHydGenStandByPower'][g] * optmodel.vHydGenStandBy[p,sc,n,g] == sum(optmodel.vHydGenPWLWeight[p,sc,n,g,k] * model.pwl_curve[g][k][0] for k in model.pwlbp)
+        optmodel.__setattr__('ePWLPower', Constraint(psn_hpwl, rule=ePWLPower, doc='electrolyser PWL productive electricity from breakpoint weights'))
+
+        def ePWLHydrogen(optmodel, p,sc,n,g):
+            return optmodel.vHydTotalOutput[p,sc,n,g] == sum(optmodel.vHydGenPWLWeight[p,sc,n,g,k] * model.pwl_curve[g][k][1] for k in model.pwlbp)
+        optmodel.__setattr__('ePWLHydrogen', Constraint(psn_hpwl, rule=ePWLHydrogen, doc='electrolyser PWL hydrogen output from breakpoint weights'))
 
     # Electrolyser three-state model (on / standby / off): on and standby are mutually
     # exclusive, off is the remainder. Only built where the unit has a standby capability

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -259,6 +259,55 @@ def test_electrolyser_standby_selected(sizing_cases_built):
                 f"electrolyser produced hydrogen while in standby at {n}"
 
 
+@pytest.mark.solve
+def test_electrolyser_pwl_efficiency(sizing_cases_built, tmp_path):
+    """B1: with the piecewise-linear part-load efficiency flag on, the electrolyser uses the
+    PWL conversion instead of the constant ProductionFunction. Verify the curve is built and
+    correct (full load reproduces the constant PF, the curve genuinely varies away from it),
+    the linear conversion is skipped for the PWL unit, the case solves, and the SOS2 condition
+    holds in the solution (weights nonzero on at most two adjacent breakpoints per hour)."""
+    import shutil
+
+    import duckdb
+
+    src = os.path.join(sizing_cases_built, "ElectrolyserStandby.duckdb")
+    dst = os.path.join(str(tmp_path), "ElectrolyserStandby.duckdb")
+    shutil.copy(src, dst)
+    con = duckdb.connect(dst)
+    cols = [r[0] for r in con.execute(
+        "SELECT column_name FROM information_schema.columns WHERE table_name='data_Option'").fetchall()]
+    if "IndBinElectrolyserPWL" not in cols:
+        con.execute("ALTER TABLE data_Option ADD COLUMN IndBinElectrolyserPWL INTEGER")
+    con.execute("UPDATE data_Option SET IndBinElectrolyserPWL = 1")
+    con.close()
+
+    model = routine(dir=str(tmp_path), case="ElectrolyserStandby", solver="highs",
+                    date=datetime.datetime.now().replace(second=0, microsecond=0),
+                    rawresults="False", plots="False", indlog="False", duckdbresults="False")
+    assert model is not None
+    u = "AEL_01"
+
+    # the PWL is active for the electrolyser and its variables are built
+    assert u in model.hpwl, f"PWL not enabled for {u}; hpwl={list(model.hpwl)}"
+    assert hasattr(model, "vHydGenPWLWeight"), "PWL weight variable not built"
+    # the constant-efficiency conversion is skipped for the PWL unit
+    assert not any(idx[-1] == u for idx in model.eAllEnergy2Hyd), \
+        "the linear conversion is still built for the PWL electrolyser"
+
+    # curve correctness: full-load breakpoint reproduces the constant PF; the curve genuinely
+    # varies away from it (real part-load efficiency, not a trivial reproduction)
+    pf = float(model.Par["pHydGenProductionFunction"][u])
+    se = [x / y for (x, y) in model.pwl_curve[u]]   # specific energy [kWh/kgH2] per breakpoint
+    assert abs(se[-1] - pf) < 1e-6, "full-load PWL point must reproduce ProductionFunction"
+    assert max(abs(s - pf) for s in se) > 0.01 * pf, "PWL curve must vary from the constant PF"
+
+    # SOS2 in the solution: at most two adjacent breakpoints carry weight in any hour
+    for n in model.n:
+        nz = [k for k in model.pwlbp if model.vHydGenPWLWeight["period1", "sc01", n, u, k]() > 1e-6]
+        assert len(nz) <= 2 and (len(nz) < 2 or nz[1] == nz[0] + 1), \
+            f"SOS2 (adjacency) violated at {n}: nonzero breakpoints {nz}"
+
+
 def test_electrolyser_fcr_structure(sizing_cases_built):
     """Build (without solving) the ElectrolyserFCR case and check the electrolyser
     FCR wiring is structurally present: the e2h constraints are built, the


### PR DESCRIPTION
…Phase B / B1)

Replaces the constant ProductionFunction (kWh/kgH2) with a piecewise-linear part-load
  efficiency curve for electrolysers, gated by the new IndBinElectrolyserPWL option (default off, so
  all existing cases are byte-unchanged). The curve has 4 breakpoints spanning the unit's [MinCharge,
  MaxCharge] productive range, with specific energy equal to the full-load ProductionFunction times a
  canonical alkaline part-load multiplier (Brauns & Turek 2020: best efficiency near 85% load, worse
  toward low and full load); at full load the multiplier is 1, so the PWL reproduces the legacy linear
  conversion. The SOS2 convex combination is encoded with segment binaries because appsi/HiGHS has no
  native SOS2 support; an off or standby unit (commitment 0) gets zero weights and so zero power and
  hydrogen. New test test_electrolys  hydrogen. New test test_ the PWL is active, the
  constant-efficiency conversion is skipped, the curve is correct, and SOS2 adjacency holds in the
  solution.