### PR TITLE
feat: add configurable currency label

### DIFF
--- a/docs/factor1_electrolyser_dev_plan.md
+++ b/docs/factor1_electrolyser_dev_plan.md
@@ -72,9 +72,15 @@ throughput (IEA/IRENA cost ranges; Refaat 2026 degradation-as-cost framing). Re-
 H2Tank 6776.72 -> 6779.40, Electrolyser 6776.72 -> 6779.39 (delta +2.68 SEK = degradation 1.59 +
 fractional startup 1.08; validated by decomposition). Main + battery goldens unchanged (AEL inactive
 there). Tests: test_electrolyser_canonical_costs_and_degradation (factor2 gone, canonical values,
-degradation wired, e2h shut-down billed). DEFERRED: Currency label option (EUR/SEK/USD) -- dfOption
-is int-cast so a string Currency needs separate string-param plumbing (like pParBalanceMode); small
-follow-up, cosmetic (single canonical unit).
+degradation wired, e2h shut-down billed).
+
+CURRENCY LABEL -- DONE (branch feature/currency-label). pParCurrency (default 'SEK') read from an
+optional dfParameter 'Currency' column (string, like the DemandType precedent; dfParameter is not
+int-cast, unlike dfOption). LABEL ONLY -- single canonical unit, so no numbers change. Used in the
+objective print (oM_ProblemSolving) and the cost-result CSV column header (oM_OutputData, write-time
+rename only; 'SEK' stays the internal value-column key so helpers / links / plots are untouched).
+Test: test_currency_label (default SEK + settable to EUR via the column). Plot axis titles and the
+per-kWh price labels still read 'SEK/kWh' (secondary cosmetic, left as-is).
 
 B1. Piecewise-linear part-load efficiency (replace the constant ProductionFunction = 56.82
 kWh/kgH2). FLAG-GATED: default = constant (legacy/non-e2h cases byte-unchanged); PWL when a flag

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -138,6 +138,12 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         else:
             parameters_dict[f'pPar{indicator}'] = data_frames['dfParameter'][indicator].iloc[0]
 
+    # Currency label: the model works in a single canonical currency (a pure label -- no numbers
+    # change with it). Optional dfParameter column 'Currency' (e.g. EUR / SEK / USD); default SEK.
+    # Used for the objective print and the cost-result column header.
+    _cur = parameters_dict.get('pParCurrency', 'SEK')
+    parameters_dict['pParCurrency'] = _cur.strip() if isinstance(_cur, str) and _cur.strip() else 'SEK'
+
     parameters_dict['pDuration'       ] = data_frames['dfDuration']['Duration'] * parameters_dict['pParTimeStep']
     #parameters_dict['pLevelToIDmarket'] = data_frames['dfDuration']['IDMarket'].astype('int')
     parameters_dict['pPeriodWeight'   ] = data_frames['dfPeriod']['Weight'].astype('int')

--- a/src/el1xr_opt/Modules/oM_OutputData.py
+++ b/src/el1xr_opt/Modules/oM_OutputData.py
@@ -409,7 +409,9 @@ def saving_results(DirName, CaseName, Date, model, optmodel, indlog):
     }).join(df_static) # aappend original static granular components
 
     Output_TotalCost_Static = df_results.stack().to_frame(name='SEK').rename_axis(['Period', 'Scenario', 'Component']).reset_index()
-    Output_TotalCost_Static.to_csv(f"{_path}/oM_Result_01_rTotalCost_Static_{CaseName}.csv", index=False, sep=',')
+    # 'SEK' is the internal value-column key; the written file uses the configured currency label.
+    _currency = model.Par.get('pParCurrency', 'SEK') if hasattr(model, 'Par') else 'SEK'
+    Output_TotalCost_Static.rename(columns={'SEK': _currency}).to_csv(f"{_path}/oM_Result_01_rTotalCost_Static_{CaseName}.csv", index=False, sep=',')
 
     # -- Plotting helper function ---
     def get(df, comp):

--- a/src/el1xr_opt/Modules/oM_ProblemSolving.py
+++ b/src/el1xr_opt/Modules/oM_ProblemSolving.py
@@ -209,7 +209,8 @@ def solving_model(DirName, CaseName, SolverName, optmodel, pWriteLP, indlog):
 
     log_time('-- Total time for solving the model:', StartTime, ind_log=indlog)
 
-    print('Objective function value                  ', round(optmodel.eTotalSCost.expr(), 2), 'SEK')
+    _currency = optmodel.Par.get('pParCurrency', 'SEK') if hasattr(optmodel, 'Par') else 'SEK'
+    print('Objective function value                  ', round(optmodel.eTotalSCost.expr(), 2), _currency)
 
     # Adding SolverResults to optmodel
     optmodel.SolverResults2 = SolverResults

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -341,6 +341,35 @@ def test_electrolyser_canonical_costs_and_degradation(sizing_cases_built):
         "the electrolyser shut-down cost must still be billed via the e2h shut-down term"
 
 
+def test_currency_label(sizing_cases_built, tmp_path):
+    """The currency is a configurable label only -- the model works in a single canonical unit,
+    so no numbers change with it. It defaults to SEK and is settable via the dfParameter
+    'Currency' column (used for the objective print and the cost-result column header)."""
+    import shutil
+
+    import duckdb
+
+    from el1xr_opt.Modules.oM_Sequence import build_model
+    date = datetime.datetime.now().replace(second=0, microsecond=0)
+
+    # default currency is SEK
+    m = build_model(sizing_cases_built, "Electrolyser", date)
+    assert m.Par["pParCurrency"] == "SEK"
+
+    # settable via the dfParameter Currency column
+    dst = os.path.join(str(tmp_path), "Electrolyser.duckdb")
+    shutil.copy(os.path.join(sizing_cases_built, "Electrolyser.duckdb"), dst)
+    con = duckdb.connect(dst)
+    cols = [r[0] for r in con.execute(
+        "SELECT column_name FROM information_schema.columns WHERE table_name='data_Parameter'").fetchall()]
+    if "Currency" not in cols:
+        con.execute("ALTER TABLE data_Parameter ADD COLUMN Currency VARCHAR")
+    con.execute("UPDATE data_Parameter SET Currency = 'EUR'")
+    con.close()
+    m2 = build_model(str(tmp_path), "Electrolyser", date)
+    assert m2.Par["pParCurrency"] == "EUR"
+
+
 def test_electrolyser_fcr_structure(sizing_cases_built):
     """Build (without solving) the ElectrolyserFCR case and check the electrolyser
     FCR wiring is structurally present: the e2h constraints are built, the


### PR DESCRIPTION
  ## Summary

  Adds a configurable currency label to the model. The model works in a single
  canonical currency, so this is a pure display label — no numeric values change with it.

  - New optional `Currency` column in `dfParameter` (e.g. EUR / SEK / USD); defaults to `SEK`.
  - Read into `pParCurrency` in `oM_InputData.py`, with trimming and a fallback to `SEK`.
  - Used in two places: the objective-function print in `oM_ProblemSolving.py` and the
    cost-result CSV column header in `oM_OutputData.py` (internal value key stays `SEK`,
    written header uses the configured label).

  ## Tests

  - `test_currency_label` checks the default is `SEK` and that setting the `Currency`
    column to `EUR` propagates to `pParCurrency`.
