### PR TITLE
docs: fix stale Phase B TODO line in dev plan

### DIFF
--- a/docs/factor1_electrolyser_dev_plan.md
+++ b/docs/factor1_electrolyser_dev_plan.md
@@ -186,5 +186,5 @@ HomeBattNoFCR, HomeBattFCRDonly, HomeBattFCRNonly, Electrolyser, H2Tank. Guarded
 test_sizing_factor1_invariant (HomeBattFCRDonly + Electrolyser). factor1=1 is x1 / 1/1, so goldens
 are byte-unchanged.
 
-STILL TODO: factor2 elimination + the PWL
-part-load-efficiency feature + degradation cost (Phase B, not started).
+Phase B is now complete: factor2 elimination, the PWL part-load-efficiency feature, and the
+degradation cost are all done (see the B0+B2 and B1 status notes above).


### PR DESCRIPTION
  ## Summary

  Corrects a stale "STILL TODO" line in `docs/factor1_electrolyser_dev_plan.md`.

  The line claimed factor2 elimination, the PWL part-load-efficiency feature, and the
  degradation cost were "not started," but all three were completed and merged in earlier
  PRs (#140 for PWL, #141 for factor2 elimination + degradation). This contradicted the
  detailed B0+B2 and B1 status sections in the same document, which already mark the work done.

  Replaces the line with an accurate completion note pointing to those status sections.

  ## Scope

  - Documentation only — no code or model behavior changes.
