### PR TITLE
feat: compressor sizing (Phase 1) + electrolyser FCR literature review

### DIFF
--- a/data/sizing/make_sizing_cases.py
+++ b/data/sizing/make_sizing_cases.py
@@ -75,6 +75,11 @@ CASES = {
     # spread is what gives the tank arbitrage value to be sized against.
     "H2Tank":           dict(battery=None, fcrd=True, fcrn=True, h2=("PEMEL_01", 0.05),
                              h2_import=True, green=0),
+    # H2TankCompressor: H2Tank plus a sized compressor on the tank (PEMEL_01). The
+    # compressor is built to cover the realized charging duty -- a small end-to-end
+    # demo of Phase 1 compressor sizing. Decision/invariance case, no golden cost.
+    "H2TankCompressor": dict(battery=None, fcrd=True, fcrn=True, h2=("PEMEL_01", 0.05),
+                             h2_import=True, green=0, compressor=("PEMEL_01", 10.0, 0.05)),
     # Electrolyser: AEL_01 is the candidate; the existing tank (PEMEL_01) stays.
     # The same priced import serves the demand; the electrolyser is built only if
     # making hydrogen from retail electricity beats the import price.
@@ -227,6 +232,15 @@ def _edit_hyd(df, spec):
             for col, val in (("NoFCRD", "No"), ("NoFCRN", "No"),
                              ("EnduranceFCRD", 60.0), ("EnduranceFCRN", 60.0)):
                 df.loc[h2[0], col] = val
+        comp = spec.get("compressor")
+        if comp:
+            # Compressor sizing (Phase 1): a rated throughput and an annualized capex on
+            # one unit; every other unit stays at 0 so it is not a compressor candidate.
+            unit, nameplate, invest = comp
+            df["CompressorNameplate"] = 0.0
+            df["CompressorInvestCost"] = 0.0
+            df.loc[unit, "CompressorNameplate"] = nameplate
+            df.loc[unit, "CompressorInvestCost"] = invest
     return df
 
 

--- a/docs/lit_review_electrolyser_fcr.md
+++ b/docs/lit_review_electrolyser_fcr.md
@@ -1,0 +1,487 @@
+# Literature review: electrolyser FCR provision and co-sizing
+
+Working document seeding the related-work and novelty sections of the planned paper on
+electrolyser frequency containment reserve (FCR) in a MILP unit-commitment + investment model.
+Reviews the five papers downloaded to `temp/papers_H2` (the paywalled set), plus the open-access
+prior art already identified (Saretta 2023 and the techno-economic references surfaced in the
+intros). Date: 2026-06-14.
+
+## What we claim (to test against the literature)
+
+Our model (already implemented in `oM_ModelFormulation.py` / `oM_Investment.py`):
+
+- **(core)** A MILP unit-commitment **with investment/sizing** in which an electrolyser provides
+  **FCR-D and FCR-N** as a controllable load (FCR-up = reduce consumption, FCR-down = increase
+  consumption).
+- **(b)** FCR-**down** provision endurance is bounded by **hydrogen-tank headroom at the node**:
+  the extra hydrogen the electrolysers at a node would make while holding a down-bid over the
+  endurance window must fit in the empty headroom of the H2 stores at that node.
+- **(c)** **Joint co-sizing** of electrolyser + hydrogen tank (+ intended: compressor) where **FCR
+  revenue is part of the capex business case**.
+
+## Summary verdict
+
+| Paper | Type | Electrolyser FCR by load modulation? | FCR-down + storage endurance? | Sizing/investment + FCR revenue? | Threat to our novelty |
+|---|---|---|---|---|---|
+| Ribeiro 2023 (Iberian, SEGAN) | Dynamic sim (swing eq.) | Yes (up only; FCR+SI+FFR) | No storage, no down-reserve | No (capacity exogenous; economics deferred) | **Closest prior art — but threatens nothing.** Cite for the qualitative claim. |
+| Phan 2024 (IJHE) | Control/dynamic (droop+MPC) | Yes (up + down) | **Tank-limit mode-switch (dynamic), not an MILP constraint** | No economics, no sizing | Closest on (b) physically — cite as precedent; (b) as optimization constraint still novel |
+| Ye 2026 (Applied Energy) | Multiphysics + HIL | Yes (droop; no D/N naming) | No | No | None — supports physical realism |
+| Elhawash 2025 (IJHE) | PHIL hardware | Yes (FCR + FFR) | No (buffer assumed, not modelled) | No | None — hardware-validation citation |
+| Ranaboldo 2024 (RSER) | Review (industrial DR) | No (only Al-smelter as curtailable load) | No | No | None — context/motivation only |
+
+**Bottom line:** none of the five downloaded papers threaten (b) or (c). Four are at the
+dynamics/control/hardware layer (sub-30-second frequency response); one is an industrial-demand-
+response review. They are excellent *supporting* citations for physical realism and motivation, but
+the real novelty risk for (c) lives in techno-economic MILP papers that are **not** in this set —
+see "Critical gap" below.
+
+---
+
+## Paper 1 — Ribeiro et al. 2023 (closest prior art)
+
+**The role of hydrogen electrolysers in frequency related ancillary services: A case study in the
+Iberian Peninsula up to 2040.** F. J. Ribeiro, J. A. Peças Lopes, F. S. Fernandes, F. J. Soares,
+A. G. Madureira. *Sustainable Energy, Grids and Networks* 35 (2023) 101084.
+DOI 10.1016/j.segan.2023.101084. **Type:** MATLAB/Simulink electromechanical (swing-equation)
+dynamic simulation — NOT optimization, scheduling, or capacity expansion.
+
+**Section-by-section.**
+- *Intro:* EU Hydrogen Strategy framing; rising RES lowers inertia; electrolysers (HEs) are
+  controllable loads. Defines "critical inertia" (min inertia so reserves deploy before first
+  under-frequency load shedding). Research question: can HEs providing reserve reduce the critical
+  inertia in the Iberian Peninsula (IP)? Innovation claimed = large fleet (8 GW) collective response.
+- *Methodology:* Two-area model (IP + Continental Europe), swing equation
+  `df = (ΔP_G − ΔP_L)/(2H·s+D) + ΔP₁₋₂`, tie-line `ΔP₁₋₂ = Δδ·T·2πf`. Violation thresholds: nadir
+  < 49.2 Hz, quasi-steady < 49.8 Hz, RoCoF > 1 Hz/s. Contingency = instantaneous 3 GW IBR (PV/wind)
+  trip. Conventional FCR from coal/nuclear/gas (TGOV1)/hydro, aggregated one unit per area per tech.
+  Calibrated against the 2011 Almaraz II 1 GW loss via particle swarm.
+- *HE model:* "Seen from the grid, upward reserve from a generator = a load decrease in a HE." HEs
+  assumed at nominal power at the contingency, so they provide **upward reserve only** (load
+  reduction); the symmetric down-reserve is assumed handled by curtailable solar/wind. Three control
+  loops = three services: FCR (droop −1/R, full activation < 49.8 Hz), Synthetic Inertia (responds to
+  df/dt, gain K=5), FFR (step at 49.8 Hz). Each loop bounded by [0, AS-volume]; min = 0 (never
+  down-reserve).
+- *2040 parameters:* All IP coal gone by 2030, conventional by 2035. 12 GW HE in IP (8 GW PEM
+  modelled) — **exogenous, from forecast [33]**, not optimized. PEM ramps 2.5 pu/s (fast) / 0.5 pu/s
+  (slow). H_IP,2040 = 2.95 pu·s. Tie-line to 6.5 GW by 2040.
+- *Results:* Conventional FCR → RoCoF 0.83 Hz/s (near 1 Hz/s limit), uses only ~25% of the 430 MW IP
+  FCR volume. HE FCR → fully uses 430 MW, RoCoF 0.63 Hz/s; ramp/comms-delay improvements barely help
+  (0.63→0.60). Adding SI/FFR: SI > FFR for RoCoF; gains saturate beyond ~430 MW extra. Main outcome
+  (Fig. 13): for RoCoF ≤ 0.6 Hz/s target, critical inertia falls from ~8 pu·s (conventional FCR) to
+  ~4.2 pu·s (HE FCR) to < 3 pu·s (large fast-HE SI). Nadirs across 28 sims: 49.69–49.78 Hz.
+- *Conclusions:* HEs outperform conventional FCR on RoCoF and reduce critical inertia.
+  **"Future work will address the economics of FCR provision by HEs in existing markets."**
+
+**Targeted extraction.** Up-reserve only (under-frequency); FCR-down explicitly disregarded
+("only a loss of generation is simulated… downward reserve is disregarded"). Generic Continental
+FCR + SI + FFR, **not** Nordic FCR-D/FCR-N. No optimization. **No storage, no tank, no compressor,
+no endurance constraint, no economics.** Capacity exogenous; FCR noted as currently mandatory and
+non-remunerated in IP.
+
+**Novelty impact.** Must cite as the closest prior demonstration that Iberian electrolysers can
+deliver frequency reserve as a controllable load. Threatens **neither (b) nor (c)**: it has no
+storage/down-reserve (b absent) and no sizing/economics (c absent), and it explicitly names the
+economics as future work — which we provide. Recommended framing: *"Ribeiro et al. establish the
+dynamic feasibility of Iberian electrolyser frequency reserve but leave the economics and sizing to
+future work; we provide exactly that."* There is a companion conference paper (ref [20], 2022 SEST,
+FCR-only) to cite alongside.
+
+---
+
+## Paper 2 — Phan et al. 2024 (closest on the endurance idea)
+
+**Advanced frequency control schemes and technical analysis for large-scale PEM and Alkaline
+electrolyzer plants in renewable-based power systems.** L. V. Phan, N. P. Nguyen-Dinh, K. M. Nguyen,
+T. Nguyen-Duc. *Int. J. Hydrogen Energy* 89 (2024) 1354–1367. DOI 10.1016/j.ijhydene.2024.09.360.
+**Type:** Control/dynamic simulation (transfer-function system frequency response + MPC controller).
+
+**Section-by-section.**
+- *Intro:* Low-inertia motivation. Reviews techno-economic prior art (see Critical gap below) and
+  technical/dynamic prior art. Gap targeted: prior physical models are computation-heavy with many
+  parameters; little work on secondary control with advanced controllers. Four contributions:
+  universal SFR (U-SFR) model, MPC secondary controller, evaluation on IEEE 39-bus with >50% wind,
+  PEM-vs-Alkaline technical analysis.
+- *Electrolyzer model:* First-order-with-deadtime power tracking `G(s)=e^{−T_ini·s}·K/(T·s+1)`.
+  PEM: T_r=0.02 s, T_s=0.06 s; Alkaline: T_r=1 s, T_s=4 s (PEM ~40× faster). **Hydrogen storage
+  sub-model:** production `m_H = η·P/LHV`; tank bound `V_min ≤ V(t) ≤ V_max`;
+  `V(t)=V(t0)+∫(m_H − m'_H)dt`. While within bounds the plant freely modulates power; at a bound it
+  cannot.
+- *U-SFR:* swing equation collapsed to a fitted 2nd-order transfer function; parameters by particle
+  swarm; validated vs PSS/E on modified IEEE 39-bus, 50.83% wind (RMSE ~1e-4 Hz).
+- *Control scheme:* Primary = droop + virtual inertia (piecewise law, Eq. 10, deadband, ROCOF gain
+  RD_ely); both up and down regulation. Secondary = MPC tracking frequency deviation AND RoCoF, with
+  hard bound `ΔP_min ≤ ΔP_ely ≤ ΔP_max`.
+- *Operating modes:* **Mode 1** normal (full support); **Mode 2** storage-constraint violation —
+  when the tank nears a bound, the plant sets production = consumption, freezing tank content and
+  **stopping further frequency support**; **Mode 3** internal fault → off.
+- *Case studies (IEEE 39-bus):* Case I controllers (base nadir 49.236 Hz/RoCoF 0.958 → MPC 49.932 Hz,
+  settling 3–5 s). Case II PEM vs Alkaline (PEM nadir 49.931 @2.14 s vs Alkaline 49.679 @2.62 s).
+  Case III pre-contingency power sets available FCR headroom (0.4 GW base → only 0.3 GW FCR). **Case
+  IV** downstream storage: initial 15 kg, min 10 kg, consumption 3 kg/s, production 5 kg/s; sustained
+  up-regulation drops production below consumption, depletes tank to the floor in ~12 s → Mode 2 stops
+  support; naive ramp-to-rated worsens nadir by ~0.52 Hz and overshoots to 51.29 Hz on a fault.
+  *Finding: smaller tanks breach constraints more often, degrading frequency-support capability.*
+
+**Targeted extraction.** Modulates consumption both directions (down = increase load). Generic
+"frequency support" (primary ≈ FCR/FFR, secondary ≈ aFRR), **not** FCR-D/FCR-N. Control/dynamic, not
+MILP (embedded optimization is only PSO fitting + online MPC QP). **No sizing, no economics, no
+compressor.** **Storage-headroom endurance: YES qualitatively** — Eqs. (5)–(6) + Case IV — but as a
+real-time dynamic **mode switch**, not a reserve-vs-storage **constraint** in a scheduling/sizing
+problem, and the tank (15 kg for a 1 GW plant) is an illustrative buffer, not a sized asset.
+
+**Novelty impact.** This is the one paper that physically demonstrates "tank headroom limits
+sustained electrolyser reserve." We therefore **cannot claim to be first to observe** the effect, and
+must cite Phan 2024 (and Case IV) as the physical precedent for (b). **But our (b) as a tractable
+MILP reserve-endurance constraint — a procured FCR-down quantity bounded by node-level tank headroom
+over the delivery window, co-optimized with commitment and investment — is not done here.** Framing:
+cite Phan for the physical effect, then state prior work captures it only as a dynamic mode switch
+whereas we embed it as an optimization constraint. Also useful: Case III (pre-contingency operating
+point sets reserve headroom) supports our 2nd-block headroom coupling; PEM-vs-Alkaline response data
+supports ramp/reserve-capability parameters. **Phan's intro is also the single best lead to the
+techno-economic papers that DO threaten (c)** (Johnsen, Zheng, Matute, Samani — see below).
+
+---
+
+## Paper 3 — Ye et al. 2026 (PEM dynamics + HIL)
+
+**Dynamic modelling of PEM Electrolyzers for power system frequency control with power HIL
+validation.** Y. Ye, J. Fang, X. Ai, S. Cui, H. Li, Z. Zhong, K. Hu, X. Yang, J. R. Svensson, J. Wen.
+*Applied Energy* 413 (2026) 127504. DOI 10.1016/j.apenergy.2026.127504. **Type:** Multiphysics
+dynamic model + droop control + power-hardware-in-the-loop (8-cell, 2.5 kW PEM stack; scaled to 1 MW).
+
+**Section-by-section (condensed).** Builds a bubble-effect-dominated **two-stage** electrochemical
++ bubble-dynamics model explaining the second-scale response (Stage I near-instant power jump, Stage
+II settles as bubble coverage rises with time constant T_b; settling T_s ≈ 5·T_b). Validated on a
+power-HIL rig: voltage error 0.56%, power error 0.85% (beats RC and thermal models). Droop control
+`K_el = ΔP/Δf` with reserve bounded by ramp and operating-point limits. Results: rise time 0.20 s
+(vs generator 2.94 s); max ramp 0.644 pu/s (literature ~0.5 pu/s); simplified RC model overestimates
+max frequency deviation by 78%. MW-scale simulation: trade-off between response speed (low flow rate,
+slow bubble dynamics) and electrolytic efficiency.
+
+**Targeted extraction.** Droop frequency response by consumption modulation; positive droop sign
+(high frequency → increase consumption), consistent with FCR-down = increase load. **No** FCR-D/N
+naming, **no** optimization, **no** sizing/economics, **no** hydrogen storage or endurance. Generic
+single-bus swing-equation system; seconds/sub-second timescale.
+
+**Novelty impact.** None to (b) or (c). Excellent **supporting** citation for physical realism:
+ramp rate 0.644 pu/s, rise time 0.20 s, min load 5%, ~10 s settling — justifies treating FCR
+provision as effectively instantaneous at UC time resolution; the 78% over-credit of simplified
+models motivates an explicit physical bound; the over/under-frequency asymmetry supports separate
+up/down (FCR-D vs FCR-N) treatment.
+
+---
+
+## Paper 4 — Elhawash et al. 2025 (PHIL validation, Iberian)
+
+**Frequency support from PEM hydrogen electrolysers using Power-Hardware-in-the-Loop validation.**
+A. M. Elhawash, R. E. Araújo, J. A. Peças Lopes. *Int. J. Hydrogen Energy* 175 (2025) 151203.
+DOI 10.1016/j.ijhydene.2025.151203 (open access, CC BY-NC). **Type:** PHIL experiment — real 5 kW
+PEM stack + custom 3-level interleaved buck converter coupled to a real-time RMS model of the 2040
+Iberian / Continental Europe system (same INESC TEC lineage as Ribeiro 2023).
+
+**Section-by-section (condensed).** Two-bus IP+CE swing-equation model; FCR via droop (full at
+49.8 Hz), FFR as a step. 2040 IP FCR = 430 MW (Spain 380 + Portugal 50) of a 3 GW area loss; 12 GW HE
+assumed in IP. Real converter (3 legs, 120° shift, ripple ÷3, adaptive lead-lag current control,
+1 pu/s ramp) on dSPACE at 40 kHz. Results: at 100% FCR the 430 MW maps to ~500 W (26%) on the 5 kW
+stack at a 38% operating point; nadir ≈ 49.71 Hz. RoCoF: 0.97 (0% HE) → 0.93 (25%) → 0.81 Hz/s
+(100%). With FFR at 25% FCR: 0.93 → 0.65 (4×) → 0.63 Hz/s (10×) — diminishing returns capped by the
+1 pu/s ramp. Cross-border import cut ~141 MW (25% case). Experiment captures the double-layer
+capacitance effect absent in simulation (minimal effect on nadir/RoCoF).
+
+**Targeted extraction.** FCR (symmetric, both directions shown — over-frequency → increase
+consumption) + FFR by load modulation; **no** FCR-D/N naming. PHIL hardware, **no** optimization,
+**no** sizing/economics. A hydrogen buffer reservoir is mentioned only qualitatively to justify
+ignoring balance-of-plant dynamics over the 30 s window — **no endurance constraint**.
+
+**Novelty impact.** None to (b) or (c). Hardware-validated proof that a real PEM electrolyser
+delivers FCR/FFR as a controllable load — strong empirical anchor. Note: the paper's open assumption
+that a buffer "assures isolation" over the reserve window is exactly the hand-wave our endurance
+constraint (b) replaces with a quantitative bound — a clean way to position (b).
+
+---
+
+## Paper 5 — Ranaboldo et al. 2024 (industrial DR review — context only)
+
+**A comprehensive overview of industrial demand response status in Europe.** M. Ranaboldo et al.
+*Renewable and Sustainable Energy Reviews* 203 (2024) 114797. DOI 10.1016/j.rser.2024.114797
+(open access; FLEX4FACT project). **Type:** Literature review (184 refs).
+
+**Section-by-section (condensed).** Flexibility gap and demand-side flexibility; industrial DR
+taxonomy (implicit price-based vs explicit incentive-based; load shedding vs shifting); potential
+(~4–5% of peak load short-term; Söder et al. 4.7–7.1% across seven Northern European countries;
+industry = 38% of final energy, >40% of electricity, ~29% CO2); challenges (Table 5). Flexibility
+markets: FCR/aFRR/mFRR/RR + EU platforms FCR Cooperation, PICASSO, MARI, TERRE; FCR (EU) full
+activation 0.5 min, validity 240 min, min 1 MW; FCR Cooperation requires symmetrical bidding + high
+technical requirements, excluding many energy-intensive loads. Energy-aware manufacturing scheduling
+(SMSP/PMSP/FSSP/JSSP — dominated by implicit TOU/RTP; explicit DR under-studied). Aggregators as
+VPPs. Digitalisation. EU research projects.
+
+**Targeted extraction.** **No hydrogen electrolyser, no power-to-X, no FCR-D/N, no endurance, no
+co-sizing.** The only "electrolyser" reference is an **aluminium-smelting electrolysis furnace** used
+as a curtailable load / "virtual battery" (TRIMET/Entelios, up to 25% curtailment). The only explicit
+FCR-provision example is a battery (Peleman/Next-Kraftwerke). No FCR prices given.
+
+**Novelty impact.** None — pure context. Cite for: industrial-flexibility motivation and the
+flexibility gap; the European balancing-market structure and the ~1 MW / symmetrical-bid barriers
+that exclude energy-intensive loads; the review's own statement that explicit-DR (ancillary)
+scheduling "has received limited attention" — which positions our electrolyser-FCR investment model
+as filling that gap.
+
+---
+
+## Paper 6 — Saretta, Raheli & Kazempour 2023 (closest operational prior art)
+
+**Electrolyzer Scheduling for Nordic FCR Services.** M. Saretta, E. Raheli, J. Kazempour (DTU).
+2023 IEEE SmartGridComm, pp. 1–6. DOI 10.1109/SmartGridComm57358.2023.10333890; preprint
+arXiv:2306.10962 (open). Code: github.com/mrc-srt/electrolyzer_nordic_FCR. **Type:** deterministic
+MILP operational scheduling/bidding (price-taker, hourly, full-year 2022 perfect-foresight case).
+
+**Section-by-section (condensed).**
+- *Nordic FCR markets:* three products — FCR-N (symmetric, ±49.9–50.1 Hz droop), FCR-D Up, FCR-D
+  Down; pay-as-bid D-2 (~80%) and D-1 (~20%) auctions; piecewise activation functions; alkaline
+  ramp ~20%/s eligible for all three.
+- *Model:* a 10 MW alkaline electrolyzer in DK2 buys grid power, makes/compresses/stores hydrogen,
+  serves a weekly demand at a fixed €/kg, and bids FCR. **Objective** = hydrogen sales + the three
+  FCR **capacity** payments − power (spot+TSO+DSO) − start-up. **Activation payment deliberately
+  excluded** (FCR-N ~symmetric over a year; FCR-D activated <1% of hours in DK2).
+- *Constraints:* power split electrolyzer/compressor; three-state on/standby/off; start-up
+  detection; **5-segment piecewise-linear part-load efficiency**; compressor power `p^c = K^c·h^p`;
+  **hydrogen storage SOC** `h^s_t = h^p_t − d_t + h^s_{t-1}`, bounded `h^s_t ≤ H^max`; weekly
+  minimum-delivery (HPA) constraint. **Reserve-allocation (the headroom logic):**
+  `p^e − r^{FCR-N} − r^{FCR-D↑} ≥ P^min` (room to reduce load) and
+  `p^e + r^{FCR-N} + r^{FCR-D↓} ≤ P^max` (room to increase load); FCR-N bounded by (P^max−P^min)/2.
+- *Results:* annual profit **0.73 M€**, revenue 3.43 M€ split hydrogen 28% / FCR-N 2% / FCR-D Down
+  30% / FCR-D Up 40% → **72% of revenue from FCR**. Conclusion explicitly: this profit is *"still
+  insufficient to recover the investment cost… an in-depth analysis is left for future work"*
+  (alkaline capex ~1 M€/MW).
+
+**Targeted extraction.** FCR-D Up/Down and FCR-N by consumption modulation, up = reduce / down =
+increase, **three separate bids, FCR-N symmetric** — a precise match to our operational framing.
+Deterministic MILP, price-taker, hourly. **Crucially: it HAS a hydrogen tank, a compressor, part-load
+PWL efficiency, three-state commitment, and an HPA constraint — the same operational skeleton as
+el1xr.** But: **(b)** reserves are bounded **only by the electrical range [P^min, P^max]**; the
+storage SOC is driven solely by *baseline* production/demand and is **never coupled to the reserve
+bid** — there is no "FCR-down must fit in tank headroom" constraint (they justify this by negligible
+activation). **(c)** all capacities (10 MW, 60,500 kg tank, compressor) are **fixed parameters** — no
+sizing; investment recovery is **named as future work**.
+
+**Novelty impact.** This is the **single closest prior art** for the operational FCR-D/N electrolyzer
+model and must be cited as the baseline (including its electrical-headroom reserve constraints, which
+mirror ours). It does **not** do (b) — its reserve is power-bounded, not tank-headroom-bounded — and
+it does **not** do (c) — fixed assets, investment explicitly deferred. So Saretta *clears* both our
+contributions and even hands us (c) as its stated future work. One caveat it exposes: our
+tank-headroom FCR-down endurance constraint only **binds** when the tank is scarce and/or activation
+is non-negligible — state that assumption explicitly so a referee sees why our constraint is needed
+where Saretta's is not.
+
+## Paper 7 — Dadkhah et al. 2022 (the (c) pre-emption)
+
+**Techno-Economic Analysis and Optimal Operation of a Hydrogen Refueling Station Providing Frequency
+Ancillary Services.** A. Dadkhah, D. Bozalakov, J. De Kooning, L. Vandevelde. *IEEE Trans. Industry
+Applications* 58(4):5171–5183, 2022. DOI 10.1109/TIA.2022.3167377 (green OA, UGent). **Type:**
+probabilistic (scenario) MILP for **joint sizing + operation** of a hydrogen refuelling station (HRS).
+
+**What it does.** Maximizes annual profit = hydrogen sales (mobility + industry + gas grid) + FAS
+capacity + activation revenue − electricity − **annualized CAPEX of every subcomponent**. Decision
+variables include the **sizes** of the electrolyser `C^E`, each compressor `C_c`, and each storage
+tank `C_t` (Eq. 1 CAPEX term `Σ_u 1.1·C^u·(IC+RC)+C^u·OC`). Products: **continental symmetric FCR +
+aFRR-up/down + mFRR-up** (NOT Nordic FCR-D/N). Single HRS at Zeebrugge, hourly, 8784 h, 100 scenarios,
+price-taker. **No unit commitment** (no on/off binary, min-up/down, or start-up — the 5–100% FCR
+baseline keeps it always on). Results: electrolyser sized 4.5→6.5 MW to host FCR/aFRR-down; profit
+uplift FCR +5%, aFRR-down +18%, **aFRR-up +58%**, mFRR-up +27%.
+
+**Decisive extraction.** **(c): YES — it jointly sizes electrolyser + compressor + tank with
+ancillary revenue in the capex objective.** Quote (contribution 3): *"The economic feasibility of the
+investment… is further improved via optimal sizing of subcomponents acknowledging the effect of
+providing various grid services on the system rating."* **This pre-empts the GENERAL (c) claim.**
+**(b): NO.** The down-reserve bid `R_s` is bounded **only by electrical power** (Eq. 2a:
+`0.05·C^E + R_s ≤ P^0 ≤ C^E − R_s`). Storage appears as an SOC balance (Eqs. 11–12) + an upper cap
+`S ≤ C_St` (Eq. 16) + a demand-based **minimum floor** (Eq. 17, `max_h H^demand ≤ S` — a *lower*
+bound for supply security, the opposite direction). **No headroom bound ties the down-reserve bid to
+remaining empty tank volume.** (b) survives.
+
+**Novelty impact.** Cite as the paper that already co-sizes electrolyser + compressor + tank with
+frequency-reserve revenue — **do not claim that combination as new.** Differentiators: Nordic FCR-D/N
+(vs continental FCR + aFRR/mFRR), genuine unit-commitment (they have none), transmission-node/network
+(they are a single station), and the tank-headroom FCR-down endurance constraint (b). Companion paper
+worth pulling to fully secure the boundary: Dadkhah et al. 2021, IJHE 46(2):1488–1500
+(DOI 10.1016/j.ijhydene.2020.10.130).
+
+## Paper 8 — Johnsen et al. 2026 (the (b) near-miss — cite and differentiate carefully)
+
+**The value of ancillary services for electrolyzers.** A. G. Johnsen, L. Mitridati, D. Zarrilli,
+J. Kazempour. *Computers & Chemical Engineering* 204:109360 (2026); preprint arXiv:2310.04321 (open).
+**Type:** deterministic MILP day-ahead self-scheduling + reserve bidding of a **single fixed-capacity**
+electrolyzer + analytical reserve bid-curve (opportunity-cost) derivation. DK1 data 2021–2023,
+price-taker.
+
+**What it does.** Objective = hydrogen + mFRR-up/down capacity + FCR (4-h block) capacity − day-ahead
+energy; **no capex, no sizing variable** (capacity fixed 10 MW; compressor folded into the production
+curve). Products: **continental symmetric FCR + mFRR-up** (NOT Nordic FCR-D/N). PWL efficiency,
+three-state on/standby/off. Headline: reserve participation lifts profit **~27% (2021) … ~47%
+(2023)**; FCR's 4-h block disadvantages it vs mFRR; tube-trailer storage; unserved-H2 analysis.
+
+**Decisive extraction.** **(c): NO — nothing is sized** (fixed 10 MW, no capex term, compressor not
+modelled). Does NOT pre-empt (c). **(b): the closest existing construct — must cite and differentiate
+precisely.** Two places: (i) the reserve-**capacity** bid bound (Eq. 3b
+`r^F + r^{m↓} ≤ C^e(1−z^off) − p^tot`) is **purely electrical, no tank term**; (ii) at the
+**activation-feasibility** stage (Eqs. 4j–4n), the extra hydrogen from *activated* down-reserve must
+fit tube-trailer storage via an SOC accumulation `s^d_t = s^d_{t−1} + h^d_t`, `s^d_t ≤ S^d`. So they
+**do couple down-activation to storage SOC** — but as an *activated-mass feasibility check*, not a
+**headroom bound on the reserve capacity bid**, and not for Nordic products.
+
+**Novelty impact — IMPORTANT framing caveat.** The claim *"no prior work links down-reserve to
+hydrogen storage"* is **too strong and would be challenged** — Johnsen couples down-activation to a
+storage SOC balance. The defensible claim is sharper: *Johnsen et al. couple down-reserve **activation
+feasibility** to a storage SOC balance at the bidding stage; we instead bound the down-reserve
+**capacity** directly by node-level tank headroom as an endurance constraint, inside an investment
+model that co-sizes the tank.* Cite Johnsen as the strongest operational prior art; their public code
+(github.com/andreagloppen/Value_of_AS_ELY) can confirm Eq. 3b has no storage term before finalizing
+the wording.
+
+## Final novelty verdict (after all 8 papers)
+
+**(c) "co-size electrolyser + tank + compressor with ancillary-service revenue" — NOT novel in
+general.** Dadkhah 2022 does exactly this (and Scolaro & Kittner sizes the electrolyser). Do not claim
+it as new.
+
+**(b) "tank-headroom-bounded FCR-down endurance" — survives, but frame precisely.** No reviewed paper
+puts a tank-headroom term in the reserve **capacity** constraint. The nearest is Johnsen's
+SOC-coupled *activation*-feasibility check — cite and distinguish (capacity-headroom/endurance vs
+activated-mass SOC). Dadkhah/Saretta bound reserve only electrically.
+
+**The defensible contribution is the COMBINATION, stated honestly:** each ingredient has a precedent
+— Saretta (Nordic FCR-D/N **operation**), Dadkhah (co-sizing with **continental** AS revenue), Johnsen
+(down-reserve↔storage coupling) — but no prior work brings them together. Specifically novel:
+1. **Nordic FCR-D + FCR-N co-sizing** — no one sizes assets for the Nordic asymmetric-D/symmetric-N
+   products (Saretta does D/N but fixed assets; Dadkhah/Johnsen size/operate but continental FCR).
+2. **Tank-headroom FCR-down endurance in the reserve-capacity bound** — distinct from Johnsen's
+   activation-feasibility SOC check.
+3. **Genuine unit-commitment + investment at a transmission node / network** — Dadkhah (no UC, single
+   station), Johnsen (no sizing, single asset), Saretta (no sizing, single asset) each lack at least
+   one of {UC, investment, network}.
+
+Recommended one-line positioning: *"Prior work either schedules an electrolyser for Nordic FCR-D/N
+with fixed assets (Saretta 2023), or co-sizes an electrolyser-storage-compressor system for
+continental FCR/aFRR/mFRR revenue (Dadkhah 2022; Johnsen 2026) — but none co-sizes for the Nordic
+FCR-D/N products, embeds a hydrogen-tank-headroom FCR-down endurance constraint in the reserve
+capacity, or does so within a network unit-commitment-and-investment model. We close that gap."*
+
+## Cross-cutting novelty assessment
+
+1. **Layer split.** All four technical papers operate at the **dynamics/control/hardware layer**
+   (sub-30-second frequency response, RoCoF, nadir). Our work is at the **operations + investment
+   layer** (UC + sizing economics). They answer "can the electrolyser physically deliver the reserve
+   fast enough?" — we answer "how much to build and is the FCR revenue worth the capex?" These are
+   complementary; cite them to establish physical feasibility, then state the economic/sizing question
+   is open.
+
+2. **(b) tank-headroom FCR-down endurance.** Physically precedented by **Phan 2024** (Case IV /
+   Mode 2: tank limit stops sustained support) — cite it. Not precedented as an **MILP reserve-
+   endurance constraint** anywhere in this set. Likely novel as a formulation; claim it carefully
+   ("we encode, as a tractable UC+investment constraint, the storage-headroom limit that prior work
+   captures only as a dynamic mode switch").
+
+3. **(c) joint co-sizing with FCR revenue.** Untouched by all six reviewed papers (the five dynamics
+   papers + Saretta all use fixed capacities). **But NOT cleared, and now at real risk:** the DOI
+   round found that **Dadkhah 2022** sizes electrolyser + compressor + storage tanks with capex AND is
+   storage-aware for reserve, and **Johnsen** (CCE 2026 / arXiv:2310.04321) does operation + sizing
+   with storage-limited reserve and FCR-D/N. So "co-size an electrolyser + tank + compressor while
+   earning ancillary-service revenue" is, in general, **already done** (Dadkhah; also Scolaro sizes
+   the electrolyser). The defensible novelty must therefore be **narrowed** to the specific
+   combination not yet shown: **(i) FCR-D + FCR-N (Nordic primary reserve) specifically**, with
+   **(ii) the tank-headroom-bounded FCR-DOWN endurance constraint (b)**, inside **(iii) a
+   transmission-node UC+investment model** — Dadkhah uses aFRR/mFRR (not FCR-D/N) for a single
+   refuelling station, and on abstract evidence none couple FCR-down to tank headroom. Confirm by
+   reading Dadkhah and Johnsen in full before claiming any "first".
+
+4. **FCR-D / FCR-N (Nordic split).** None of the five use it; they use generic Continental FCR (+ SI
+   + FFR) or generic FCR. Our explicit FCR-D + FCR-N treatment with separate up/down and symmetric N
+   is a distinguishing detail (shared with the open-access Saretta 2023 Nordic scheduling paper).
+
+## Techno-economic MILP papers — resolved fetch list + threat assessment
+
+DOIs resolved 2026-06-14. These are the real novelty risks for **(c)** (and possibly **(b)**),
+because several actually SIZE the assets — unlike the five dynamics papers and Saretta. Abstract-level
+flags below; the two HIGH open-access ones must be read in full before any "first co-sizing" claim.
+
+| # | Paper | DOI / id | Open? | Sizes assets? | Storage-aware reserve? | Reserve product | Priority |
+|---|---|---|---|---|---|---|---|
+| 1 | **Johnsen et al.** "The value of ancillary services for electrolyzers" | 10.1016/j.compchemeng.2025.109360; preprint **arXiv:2310.04321** | preprint YES | **Yes (operation + sizing)** | **Yes (storage-limited reserve)** | FCR-D/FCR-N + mFRR (DK1) | **HIGH** |
+| 2 | Zheng et al. "P2H providing frequency regulation reserves, Denmark" | 10.1016/j.ijhydene.2023.03.253 | YES (DTU Orbit) | unclear | unclear | FCR + aFRR | MED |
+| 3 | Matute et al. "Multi-MW electrolyser grid services, Spain (FCEV)" | 10.1016/j.ijhydene.2019.05.092 | No (paywalled) | feasibility across sizes | not flagged | secondary freq. control | MED-HIGH |
+| 4 | Samani et al. "25 MW electrolyser primary reserve, Belgium" | 10.1049/iet-rpg.2020.0453 (IET) | YES (OA) | No (fixed 25 MW, set-point) | not flagged | FCR (100 mHz symmetric) | MED |
+| 5 | Scolaro & Kittner "Hybrid offshore wind H2, Germany" | 10.1016/j.ijhydene.2021.12.062 | No (paywalled) | **Yes (sizes electrolyzer)** | not flagged | German control reserve (generic) | **HIGH** |
+| 6 | **Dadkhah et al.** "Probabilistic MILP, HRS providing frequency ancillary services" | 10.1109/TIA.2022.3167377 | YES (green, UGent) | **Yes (electrolyser + compressor + tanks, with capex)** | **Yes (storage-aware reserve)** | aFRR-Up/Down + mFRR-Up (not FCR-D/N) | **HIGH** |
+| 7 | Saretta et al. (reviewed above) | 10.1109/SmartGridComm57358.2023.10333890; arXiv:2306.10962 | YES | No | No | FCR-D + FCR-N | done |
+
+**This sharpens the novelty picture — see the verdict below.** Identity corrections vs the original
+leads: Scolaro is *Michele* (not Manuel), IJHE not Energy Policy; Matute is **2019** not 2021–23;
+Samani (not Amani) is IET RPG; Saretta is IEEE SmartGridComm 2023; Johnsen's "57%" figure is from an
+unpublished 2022 DTU thesis, citable version is CCE 2026 / arXiv:2310.04321 (refined to "up to 47%").
+
+**Paywalled DOIs to fetch with RISE credentials → `temp/papers_H2`:** #3
+`10.1016/j.ijhydene.2019.05.092` (Matute) and #5 `10.1016/j.ijhydene.2021.12.062` (Scolaro &
+Kittner). Everything else (Johnsen preprint, Zheng, Samani, Dadkhah, Saretta) is open access.
+
+**Immediate next reads (open access, no credentials):** #1 Johnsen (arXiv:2310.04321) and #6 Dadkhah
+(IEEE TIA 2022) — the only two flagged as doing BOTH sizing AND storage-aware reserve. They are the
+decisive tests of (b) and (c).
+
+## Consolidated BibTeX
+
+```bibtex
+@article{Ribeiro2023HydrogenElectrolysersFrequencyAS,
+  author  = {Ribeiro, Fernando J. and Pe{\c{c}}as Lopes, Jo{\~a}o A. and Fernandes, Francisco S. and Soares, Filipe J. and Madureira, Andr{\'e} G.},
+  title   = {The role of hydrogen electrolysers in frequency related ancillary services: A case study in the Iberian Peninsula up to 2040},
+  journal = {Sustainable Energy, Grids and Networks},
+  volume  = {35}, pages = {101084}, year = {2023},
+  issn = {2352-4677}, doi = {10.1016/j.segan.2023.101084}, publisher = {Elsevier}
+}
+@article{Phan2024ElectrolyzerFrequencyControl,
+  author  = {Phan, Long Van and Nguyen-Dinh, Nghia Phu and Nguyen, Khai Manh and Nguyen-Duc, Tuyen},
+  title   = {Advanced frequency control schemes and technical analysis for large-scale {PEM} and {Alkaline} electrolyzer plants in renewable-based power systems},
+  journal = {International Journal of Hydrogen Energy},
+  volume  = {89}, pages = {1354--1367}, year = {2024},
+  issn = {0360-3199}, doi = {10.1016/j.ijhydene.2024.09.360}, publisher = {Elsevier}
+}
+@article{Ye2026PEMElectrolyzerFrequencyHIL,
+  author  = {Ye, Yurun and Fang, Jiakun and Ai, Xiaomeng and Cui, Shichang and Li, Hao and Zhong, Zhiyao and Hu, Kewei and Yang, Xiaobo and Svensson, Jan R. and Wen, Jinyu},
+  title   = {Dynamic modelling of {PEM} Electrolyzers for power system frequency control with power {HIL} validation},
+  journal = {Applied Energy},
+  volume  = {413}, pages = {127504}, year = {2026},
+  issn = {0306-2619}, doi = {10.1016/j.apenergy.2026.127504}, publisher = {Elsevier}
+}
+@article{Elhawash2025FrequencySupportPEM,
+  author  = {Elhawash, Abdelrahman M. and Ara{\'u}jo, Rui Esteves and Pe{\c{c}}as Lopes, Jo{\~a}o A.},
+  title   = {Frequency support from {PEM} hydrogen electrolysers using Power-Hardware-in-the-Loop validation},
+  journal = {International Journal of Hydrogen Energy},
+  volume  = {175}, pages = {151203}, year = {2025},
+  issn = {0360-3199}, doi = {10.1016/j.ijhydene.2025.151203}, note = {Open access, CC BY-NC 4.0}
+}
+@article{Ranaboldo2024IDR,
+  author  = {Ranaboldo, M. and Arag\"{u}\'{e}s-Pe\~{n}alba, M. and Arica, E. and others},
+  title   = {A comprehensive overview of industrial demand response status in Europe},
+  journal = {Renewable and Sustainable Energy Reviews},
+  volume  = {203}, pages = {114797}, year = {2024},
+  issn = {1364-0321}, doi = {10.1016/j.rser.2024.114797}, note = {Open access (CC BY-NC)}
+}
+@article{Saretta2023ElectrolyzerNordicFCR,
+  author  = {Saretta, Marco and Raheli, Enrica and Kazempour, Jalal},
+  title   = {Electrolyzer Scheduling for {Nordic} {FCR} Services},
+  journal = {arXiv preprint arXiv:2306.10962}, year = {2023}, eprint = {2306.10962}
+}
+```
+
+## Recommended citation map per claim
+
+- "Electrolysers can physically deliver fast FCR/FFR as a controllable load" → Ye 2026, Elhawash 2025
+  (hardware), Phan 2024, Ribeiro 2023.
+- "Iberian electrolyser frequency reserve, feasibility shown, economics left open" → Ribeiro 2023
+  (+ companion conf. [20]).
+- "Hydrogen-storage headroom physically limits sustained electrolyser reserve" → Phan 2024 (Case IV).
+- "Industrial-flexibility / DR market context and barriers" → Ranaboldo 2024.
+- "Operational FCR-D/FCR-N electrolyzer scheduling (Nordic)" → Saretta 2023.
+- Our distinct contributions: (b) storage-headroom-bounded FCR-down endurance as an MILP constraint;
+  (c) joint co-sizing of electrolyser + tank + compressor with FCR revenue — pending the
+  techno-economic review round above.

--- a/docs/scope_electrolyser_compressor_sizing.md
+++ b/docs/scope_electrolyser_compressor_sizing.md
@@ -1,0 +1,138 @@
+# Scope: compressor sizing (hydrogen-storage compressor as an investment decision)
+
+Concrete design for making the hydrogen compressor an **investment/sizing decision**, alongside the
+electrolyser and the tank, which are already sized via `vHydGenInvest`. Today the compressor has no
+capacity variable and no capex — its electricity draw is a fixed ratio of the tank charge flow. This
+closes that gap and (optionally, Phase 2) couples the built compressor rate to FCR-down endurance.
+
+## Motivation
+
+The electrolyser makes hydrogen at low pressure; storing it requires compression, which draws
+electricity. el1xr already captures the *energy* (`pHydGenMaxCompressorConsumption[hgs]` kWh/kg ×
+`vHydTotalCharge` kg in the electricity balance), but not the compressor as a *capacity*:
+
+- a real compressor has a **rated throughput** (kg/h) that limits how fast the tank can be filled;
+- it has a **capital cost** that scales with that rating.
+
+A sized compressor matters economically (cheap-slow vs expensive-fast) and physically (it caps the
+rate at which sustained FCR-down can push extra hydrogen into the tank — the endurance story).
+
+## Current gap
+
+Electrolyser and tank are sized via `vHydGenInvest ∈ [0,1]` build-fractions with `pHydGenInvestCost`
+capex (`oM_Investment.py`). The compressor has neither a capacity variable nor a capex term — its
+draw is just a fixed ratio of `vHydTotalCharge`. It is the one asset of the three with no investment
+decision.
+
+## Design principles
+
+- **Match the existing investment convention** (build-fraction × nameplate, optional binary), so it
+  composes with `pHydGenBinaryInvestment`, the investment bounds, and `eTotalICost`.
+- **Default-off ⇒ byte-unchanged.** No compressor data ⇒ no variable, no constraint, no capex ⇒
+  every existing golden is bit-for-bit identical (same gating as electrolyser/tank investment).
+- **Respect the factor1 classification** (Phase A): nameplate is a quantity (× factor1); capex is an
+  investment lump sum (drops factor1).
+
+## Modelling choice — size by throughput
+
+Compressor consumption is linear in mass flow (constant kWh/kg), so throughput (kg/step) and rated
+power (kW) are equivalent up to that constant. **Size by throughput** — `pHydGenCompNameplate[hgs]`
+in kg/step — because it bounds `vHydTotalCharge` directly, in the same units/convention as the
+existing tank-charge bound `pHydMaxCharge`. (Power-based sizing is just this divided by the kWh/kg
+ratio — no added expressiveness.)
+
+## Model objects
+
+**Set** (candidates only, so default-off holds):
+
+    hgcompc = [ hgs in model.hgs : pHydGenCompInvestCost[hgs] > 0 ]
+
+**Data columns** on the hydrogen-generation input (both optional, default 0 → no-op):
+
+| Column | Param | Meaning | Units | factor1 |
+|---|---|---|---|---|
+| `CompressorNameplate` | `pHydGenCompNameplate[hgs]` | rated compressor throughput | kgH2/step | quantity → x factor1 |
+| `CompressorInvestCost` | `pHydGenCompInvestCost[hgs]` | annualized capex per unit nameplate | currency | lump sum → drops factor1 |
+
+**Variable** (mirrors `vHydGenInvest`):
+
+    vHydCompInvest[hgs] in [0,1]      for hgs in hgcompc
+
+Continuous by default; Binary if the storage unit's `pHydGenBinaryInvestment[hgs] == 1` (reused, no
+new flag in Phase 1).
+
+## Constraints
+
+**Core — duty bound** (`oM_Investment.py`, beside `eHydInvestMaxStorageCharge`), per `(p,sc,n)`,
+`hgs in hgcompc`:
+
+    vHydTotalCharge[p,sc,n,hgs]  <=  pHydGenCompNameplate[hgs] * factor1 * vHydCompInvest[hgs]
+
+The compressor moves at most its built throughput. This sits alongside the tank-charge-port bound
+(`vHydTotalCharge <= pHydMaxCharge * vHydGenInvest[hgsc]`); the model takes the binding one — so a big
+tank with a small compressor (or the reverse) becomes a real choice.
+
+**Core — capex** (extend `eTotalICost`):
+
+    + sum_{hgs in hgcompc} pHydGenCompInvestCost[hgs] * vHydCompInvest[hgs]
+
+**Optional (Phase 2) — FCR-down rate coupling** (`oM_ModelFormulation.py`, mirroring the node-level
+`eEleFreqDownEnduranceConv`). FCR-down endurance currently bounds the extra hydrogen by tank
+*headroom* (a volume limit). Physically it is also bounded by the compressor *rate*: the extra
+production from a held down-bid must fit through the spare compressor throughput at the node:
+
+    sum_{e2h @ nd} bid_down[e2h] / PF[e2h]
+      <= sum_{hgs @ nd} ( pHydGenCompNameplate[hgs]*factor1*vHydCompInvest[hgs] - vHydTotalCharge[hgs] )
+
+This makes FCR-down need both empty volume (existing) and a fast-enough compressor (new) — the
+physically complete picture.
+
+## What stays untouched
+
+- The electricity-balance term (`ratio * vHydTotalCharge`) is unchanged; we add a cap on the flow and
+  a capex, not a new per-kg energy.
+- No commitment/standby on the compressor — it stays a continuous capacity bound (consistent with how
+  el1xr models it today). Explicit non-goal.
+
+## Files
+
+- `oM_InputData.py` — read the two columns (default 0); build `hgcompc`.
+- `oM_Investment.py` — declare `vHydCompInvest`; add `eHydInvestMaxCompressor` (duty bound); extend
+  `eTotalICost`.
+- `oM_ModelFormulation.py` — Phase 2 only — add the FCR-down rate coupling.
+- `data/sizing/make_sizing_cases.py` — add the columns to whichever case(s) should size a compressor.
+- `tests/test_run.py` — structural test, default-off byte-unchanged check, a sizing-response test,
+  factor1 invariance.
+
+## Validation & tests
+
+- **Input guard:** `pHydGenCompInvestCost > 0` with `pHydGenCompNameplate == 0` → hard error (would
+  silently force `charge = 0`).
+- **Byte-unchanged:** full solve tier with compressor off.
+- **Sizing response:** high compressor capex → smaller compressor, throttled charge flow; low capex →
+  full build. Assert `vHydCompInvest` moves and the duty bound binds.
+- **factor1 invariance:** ratio 1.00000 at factor1 = 1 vs 2 with compressor sizing on.
+
+## Phasing
+
+- **Phase 1 (core):** duty bound + capex. Default-off, byte-unchanged, small and safe. Closes the
+  el1xr feature gap so all three assets are sized.
+- **Phase 2 (optional, novelty):** the FCR-down rate coupling. Re-baselines the e2h FCR goldens with
+  justification (like the earlier Phase B re-baselines). This is where compressor sizing becomes a
+  contribution — Johnsen 2026 folds the compressor away entirely, and no reviewed paper gates FCR-down
+  by compressor throughput.
+
+## Novelty note
+
+Phase 1 alone is NOT novel — Dadkhah 2022 already sizes a compressor with ancillary-service revenue;
+it is a correctness/completeness fix. Phase 2 (compressor rate gating FCR-down) is the differentiator.
+See `docs/lit_review_electrolyser_fcr.md` for the prior-art assessment.
+
+## Decisions (resolved 2026-06-14)
+
+1. Build-fraction × nameplate (consistent with existing investment layer). **Chosen.**
+2. Throughput-based nameplate. **Chosen.**
+3. Phase 1 first (goldens clean), Phase 2 as its own re-baselined PR. **Chosen.**
+4. Sizing case(s) to carry a compressor: TBD during implementation (a case that already has H2 tank +
+   compressor consumption).
+5. Reuse the storage unit's binary/bounds flags (no new flag in Phase 1). **Chosen.**

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -371,6 +371,26 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         parameters_dict['pHydGenMaxCompressorConsumption'] = parameters_dict['pHydGenMaxCompressorConsumption'].fillna(0.0)
     else:
         parameters_dict['pHydGenMaxCompressorConsumption'] = pd.Series(0.0, index=parameters_dict['pHydGenProductionFunction'].index)
+    # Compressor sizing (Phase 1): an optional investment decision for the compressor that
+    # charges a hydrogen store. CompressorNameplate is the rated throughput (same units as the
+    # charge flow it bounds); CompressorInvestCost is its annualized capex. Both default to 0
+    # when the column is absent, so cases without them build unchanged, and a unit is only a
+    # compressor-sizing candidate when its CompressorInvestCost is positive. The nameplate is a
+    # quantity left UNSCALED here and multiplied by factor1 at the use site
+    # (oM_Investment.eHydInvestMaxCompressor), matching the pHydMaxStorage scale-at-use pattern;
+    # the capex is an investment lump sum and is never factor1-scaled.
+    for _comp_col in ['pHydGenCompressorNameplate', 'pHydGenCompressorInvestCost']:
+        if _comp_col in parameters_dict:
+            parameters_dict[_comp_col] = parameters_dict[_comp_col].fillna(0.0)
+        else:
+            parameters_dict[_comp_col] = pd.Series(0.0, index=parameters_dict['pHydGenProductionFunction'].index)
+    _comp_bad = [g for g in parameters_dict['pHydGenCompressorInvestCost'].index
+                 if parameters_dict['pHydGenCompressorInvestCost'][g] > 0.0
+                 and parameters_dict['pHydGenCompressorNameplate'][g] <= 0.0]
+    if _comp_bad:
+        raise ValueError(f"Compressor sizing: hydrogen unit(s) {_comp_bad} have CompressorInvestCost > 0 "
+                         f"but CompressorNameplate <= 0; a candidate compressor needs a positive nameplate "
+                         f"throughput, otherwise its charge flow would be forced to zero.")
     # Electrolyser (e2h) FCR participation flags and endurance. When the hydrogen-
     # generation data omits these columns the flags default to 1 ("not participating")
     # and the endurance to 0, so existing cases are unaffected. An electrolyser only
@@ -431,6 +451,7 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     model.hgs  = Set(doc='hydrogen storage       units ', initialize=[hgs    for hgs  in           model.hg  if  parameters_dict['pHydGenMaximumStorage']   [hgs]  >  0.0 and (parameters_dict['pVarMaxInflows'].sum()     [hgs] >  0.0 or  parameters_dict['pVarMaxOutflows'].sum()    [hgs] >  0.0 or parameters_dict['pHydGenMaximumCharge'][hgs] > 0.0)])
     model.hgc  = Set(doc='hydrogen candidate     units ', initialize=[hgc    for hgc  in           model.hg  if  parameters_dict['pHydGenInvestCost']       [hgc]  >  0.0])
     model.hgsc = Set(doc='hydrogen storage       units ', initialize=[hgsc   for hgsc in           model.hgs if  parameters_dict['pHydGenInvestCost']      [hgsc]  >  0.0])
+    model.hgcompc = Set(doc='hydrogen compressor candidate', initialize=[hgs for hgs in           model.hgs if  parameters_dict['pHydGenCompressorInvestCost'][hgs] >  0.0])
     model.e2h  = Set(doc='ele2hyd                units ', initialize=[hg     for hg   in           model.hg  if  parameters_dict['pHydGenProductionFunction'][hg]  >  0.0])
     model.h2e  = Set(doc='hyd2ele                units ', initialize=[eg     for eg   in           model.eg  if  parameters_dict['pEleGenProductionFunction'][eg]  >  0.0])
     # Audit C39: a generation unit whose InitialPeriod is after the economic base year is

--- a/src/el1xr_opt/Modules/oM_Investment.py
+++ b/src/el1xr_opt/Modules/oM_Investment.py
@@ -49,7 +49,7 @@ def create_investment(model, optmodel, indlog):
     # unit -- EUR (whatever native currency the data uses; the demo prints SEK). Label fixed.
     setattr(optmodel, 'vTotalICost', Var(within=NonNegativeReals, doc='total annualized investment cost [EUR]'))
 
-    if not len(model.egc) and not len(model.hgc):
+    if not len(model.egc) and not len(model.hgc) and not len(model.hgcompc):
         optmodel.vTotalICost.fix(0.0)
         log_time('--- Declaring the investment layer (no candidate units):', StartTime, ind_log=indlog)
         return model
@@ -57,6 +57,9 @@ def create_investment(model, optmodel, indlog):
     # %% Build-decision variables (fraction of nameplate built, in [0, 1])
     setattr(optmodel, 'vEleGenInvest', Var(model.egc, within=UnitInterval, doc='electricity candidate build fraction [0,1]'))
     setattr(optmodel, 'vHydGenInvest', Var(model.hgc, within=UnitInterval, doc='hydrogen    candidate build fraction [0,1]'))
+    # Compressor build fraction (sized independently of the tank charge port it shares a store
+    # with). Empty when no unit carries a CompressorInvestCost, so default cases are unchanged.
+    setattr(optmodel, 'vHydCompInvest', Var(model.hgcompc, within=UnitInterval, doc='hydrogen compressor candidate build fraction [0,1]'))
 
     # Make the decision binary (all-or-nothing build) for units flagged for it.
     for egc in model.egc:
@@ -69,6 +72,13 @@ def create_investment(model, optmodel, indlog):
         try:
             if model.Par['pHydGenBinaryInvestment'][hgc] == 1:
                 optmodel.vHydGenInvest[hgc].domain = Binary
+        except (KeyError, TypeError):
+            pass
+    # Compressor build decision reuses the storage unit's binary-investment flag (Phase 1).
+    for hgs in model.hgcompc:
+        try:
+            if model.Par['pHydGenBinaryInvestment'][hgs] == 1:
+                optmodel.vHydCompInvest[hgs].domain = Binary
         except (KeyError, TypeError):
             pass
 
@@ -100,6 +110,7 @@ def create_investment(model, optmodel, indlog):
     psnegsc = [(p, sc, n, egsc) for (p, sc, n) in model.psn for egsc in model.egsc]
     psnhgc  = [(p, sc, n, hgc ) for (p, sc, n) in model.psn for hgc  in model.hgc ]
     psnhgsc = [(p, sc, n, hgsc) for (p, sc, n) in model.psn for hgsc in model.hgsc]
+    psnhgcompc = [(p, sc, n, hgs) for (p, sc, n) in model.psn for hgs in model.hgcompc]
     # candidate electrolysers (e2h units that are investment candidates): their
     # design variable is the ELECTRICITY input, so the build decision must cap it.
     e2hc    = [g for g in model.e2h if g in model.hgc]
@@ -149,6 +160,16 @@ def create_investment(model, optmodel, indlog):
         return optmodel.vHydTotalCharge[p, sc, n, hgsc] <= model.Par['pHydMaxCharge'][hgsc][p, sc, n] * optmodel.vHydGenInvest[hgsc]
     optmodel.__setattr__('eHydInvestMaxStorageCharge', Constraint(psnhgsc, rule=eHydInvestMaxStorageCharge, doc='candidate hydrogen storage charge limited by build decision'))
 
+    # Candidate hydrogen compressor: the charge flow into the store (whose compression draws
+    # electricity, pHydGenMaxCompressorConsumption x vHydTotalCharge in the electricity balance)
+    # is limited by the BUILT compressor throughput. This sits alongside the tank charge-port cap
+    # above; the binding one wins, so a large tank can be paired with a small (cheaper, slower)
+    # compressor or vice versa. The nameplate is a quantity, so it is multiplied by factor1 at use
+    # (matching eHydInvestMaxInventory / the pHydMaxStorage scale-at-use pattern).
+    def eHydInvestMaxCompressor(optmodel, p, sc, n, hgcompc):
+        return optmodel.vHydTotalCharge[p, sc, n, hgcompc] <= model.Par['pHydGenCompressorNameplate'][hgcompc] * model.factor1 * optmodel.vHydCompInvest[hgcompc]
+    optmodel.__setattr__('eHydInvestMaxCompressor', Constraint(psnhgcompc, rule=eHydInvestMaxCompressor, doc='candidate hydrogen compressor throughput limited by build decision'))
+
     # %% Total investment cost
     # Unit scaling: model.factor1 is the conversion factor that lets the model work
     # at either utility (MWh) or local/home (kWh) scale. It is applied to the
@@ -178,7 +199,8 @@ def create_investment(model, optmodel, indlog):
     def eTotalICost(optmodel):
         return optmodel.vTotalICost == period_weight * (
             sum(model.Par['pEleGenInvestCost'][egc] * optmodel.vEleGenInvest[egc] for egc in model.egc) +
-            sum(model.Par['pHydGenInvestCost'][hgc] * optmodel.vHydGenInvest[hgc] for hgc in model.hgc))
+            sum(model.Par['pHydGenInvestCost'][hgc] * optmodel.vHydGenInvest[hgc] for hgc in model.hgc) +
+            sum(model.Par['pHydGenCompressorInvestCost'][hgs] * optmodel.vHydCompInvest[hgs] for hgs in model.hgcompc))
     optmodel.__setattr__('eTotalICost', Constraint(rule=eTotalICost, doc='total period-weighted investment cost'))
 
     log_time('--- Declaring the investment (capacity-sizing) layer:', StartTime, ind_log=indlog)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -370,6 +370,64 @@ def test_currency_label(sizing_cases_built, tmp_path):
     assert m2.Par["pParCurrency"] == "EUR"
 
 
+def test_compressor_sizing_structure(sizing_cases_built, tmp_path):
+    """Phase 1 compressor sizing: the compressor is an independent investment decision.
+    Off by default (no candidate set), and when a unit carries a CompressorInvestCost the
+    build variable, the throughput duty bound (tying the charge flow to the build fraction),
+    and the capex term in the total investment cost are all present."""
+    import shutil
+
+    import duckdb
+    from pyomo.core.expr.visitor import identify_variables
+
+    from el1xr_opt.Modules.oM_Sequence import build_model
+    date = datetime.datetime.now().replace(second=0, microsecond=0)
+
+    # default: no CompressorInvestCost column -> empty candidate set, nothing added
+    m0 = build_model(sizing_cases_built, "H2Tank", date)
+    assert len(m0.hgs) > 0, "H2Tank should have a hydrogen storage unit"
+    assert len(m0.hgcompc) == 0
+
+    # add the compressor sizing columns to the hydrogen generation table
+    dst = os.path.join(str(tmp_path), "H2Tank.duckdb")
+    shutil.copy(os.path.join(sizing_cases_built, "H2Tank.duckdb"), dst)
+    con = duckdb.connect(dst)
+    cols = [r[0] for r in con.execute(
+        "SELECT column_name FROM information_schema.columns WHERE table_name='data_HydrogenGeneration'").fetchall()]
+    for col in ("CompressorNameplate", "CompressorInvestCost"):
+        if col not in cols:
+            con.execute(f"ALTER TABLE data_HydrogenGeneration ADD COLUMN {col} DOUBLE")
+    con.execute("UPDATE data_HydrogenGeneration SET CompressorNameplate = 10.0, CompressorInvestCost = 1000.0")
+    con.close()
+
+    m = build_model(str(tmp_path), "H2Tank", date)
+    # the storage unit is now a compressor-sizing candidate, with a build variable
+    assert len(m.hgcompc) > 0
+    assert len(m.vHydCompInvest) > 0
+    # the duty bound has active rows and ties the charge flow to the build fraction
+    assert len(m.eHydInvestMaxCompressor) > 0
+    duty_vars = {v.name for v in identify_variables(next(iter(m.eHydInvestMaxCompressor.values())).body)}
+    assert any(vn.startswith("vHydTotalCharge") for vn in duty_vars)
+    assert any(vn.startswith("vHydCompInvest") for vn in duty_vars)
+    # the compressor capex enters the total investment cost
+    icost_vars = {v.name for v in identify_variables(m.eTotalICost.body)}
+    assert any(vn.startswith("vHydCompInvest") for vn in icost_vars)
+
+    # guard: a positive CompressorInvestCost with a zero nameplate fails loudly
+    bad_dir = os.path.join(str(tmp_path), "bad")
+    os.makedirs(bad_dir, exist_ok=True)
+    bad = os.path.join(bad_dir, "H2Tank.duckdb")
+    shutil.copy(os.path.join(sizing_cases_built, "H2Tank.duckdb"), bad)
+    con = duckdb.connect(bad)
+    for col in ("CompressorNameplate", "CompressorInvestCost"):
+        if col not in cols:
+            con.execute(f"ALTER TABLE data_HydrogenGeneration ADD COLUMN {col} DOUBLE")
+    con.execute("UPDATE data_HydrogenGeneration SET CompressorNameplate = 0.0, CompressorInvestCost = 1000.0")
+    con.close()
+    with pytest.raises(ValueError, match="CompressorNameplate"):
+        build_model(bad_dir, "H2Tank", date)
+
+
 def test_electrolyser_fcr_structure(sizing_cases_built):
     """Build (without solving) the ElectrolyserFCR case and check the electrolyser
     FCR wiring is structurally present: the e2h constraints are built, the

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -159,7 +159,7 @@ SIZING_CASES = [
 ]
 SIZING_CASE_NAMES = ["HomeBatt", "HoodBatt", "HomeBattNoTariff", "HomeBattNoFCR",
                      "HomeBattFCRDonly", "HomeBattFCRNonly", "H2Tank", "Electrolyser",
-                     "ElectrolyserStandby", "ElectrolyserFCR"]
+                     "ElectrolyserStandby", "ElectrolyserFCR", "H2TankCompressor"]
 SIZING_RTOL = 1e-5
 
 
@@ -190,7 +190,7 @@ def test_sizing_case_from_duckdb(case, expected, sizing_cases_built):
 
 
 @pytest.mark.solve
-@pytest.mark.parametrize("case", ["HomeBattFCRDonly", "Electrolyser"])
+@pytest.mark.parametrize("case", ["HomeBattFCRDonly", "Electrolyser", "H2TankCompressor"])
 def test_sizing_factor1_invariant(case, sizing_cases_built):
     """C38: factor1 is a true unit conversion, so the optimum is invariant under it. This guards
     the paths the main invariance test (Home1) does not exercise: FCR-D/FCR-N provision and its
@@ -241,6 +241,30 @@ def test_h2_sizing_decisions(case, unit, full_build, sizing_cases_built):
     assert hns < 1e-6, f"hydrogen demand not fully served (HNS={hns:.4f} kgH2)"
     discharge = sum(model.vHydTotalOutput["period1", "sc01", n, "PEMEL_01"]() for n in model.n)
     assert discharge > 1.0, f"tank never discharged (total {discharge:.4f} kgH2)"
+
+
+@pytest.mark.solve
+def test_compressor_sizing_decision(sizing_cases_built):
+    """Phase 1 compressor sizing, end to end: the compressor on the hydrogen tank is
+    built to a positive fraction, the tank's charge flow never exceeds the built
+    compressor throughput (the duty bound holds in the solution), and the tank
+    actually charges -- so the compressor is sized to the realized charging duty."""
+    model = routine(dir=sizing_cases_built, case="H2TankCompressor", solver="highs",
+                    date=datetime.datetime.now().replace(second=0, microsecond=0),
+                    rawresults="False", plots="False", indlog="False", duckdbresults="False")
+    assert model is not None
+    assert len(model.hgcompc) == 1, "exactly one compressor-sizing candidate expected"
+    u = next(iter(model.hgcompc))
+    frac = model.vHydCompInvest[u]()
+    assert 0.0 < frac <= 1.0 + 1e-6, f"compressor build fraction {frac:.4f}, expected a positive build"
+    built = model.Par["pHydGenCompressorNameplate"][u] * model.factor1 * frac
+    peak = 0.0
+    for idx in model.vHydTotalCharge:
+        if idx[-1] == u:
+            ch = model.vHydTotalCharge[idx]()
+            peak = max(peak, ch)
+            assert ch <= built + 1e-4, f"charge {ch:.4f} exceeds built compressor throughput {built:.4f}"
+    assert peak > 1e-3, f"tank never charged (peak {peak:.4f}), compressor sizing not exercised"
 
 
 @pytest.mark.solve


### PR DESCRIPTION
  ## Summary

  Adds the hydrogen compressor as an investment/sizing decision (Phase 1), plus the literature review and design docs behind the electrolyser-FCR + co-sizing work.

  ### Compressor sizing (Phase 1)
  The compressor was the one hydrogen asset with no investment decision — its draw was a fixed ratio of the tank charge flow, with no capacity or capex. This makes it anindependent, flag-gated sizing decision, matching the existing build-fraction convention:

  - New optional hydrogen-generation columns `CompressorNameplate` (rated throughput) and `CompressorInvestCost` (annualized capex). Both default to 0 → no candidate.
  - New candidate set `hgcompc`, build variable `vHydCompInvest ∈ [0,1]` (Binary if the unit's `pHydGenBinaryInvestment` is set).
  - New duty bound `eHydInvestMaxCompressor`: the charge flow is capped by the built be sized independently.
  - Compressor capex added to `eTotalICost`; input guard rejects cost > 0 with nameplate = 0.
  - factor1: nameplate is a quantity (× factor1 at use), capex is a lump sum (unscaled).

  ### Docs
  - `docs/lit_review_electrolyser_fcr.md` — review of 8 papers on electrolyser FCR provision and co-sizing, with a final novelty verdict.
  - `docs/scope_electrolyser_compressor_sizing.md` — the compressor sizing design (Phase 1 implemented; Phase 2, the FCR-down rate coupling, deferred to its own PR).

  ## Tests
  - `test_compressor_sizing_structure` — default-off (no candidate), and with the columns present the variable, duty bound, capex term, and input guard are all checked.
  - `test_compressor_sizing_decision` (solve) — new `H2TankCompressor` demo case: the compressor is built to a positive fraction, the duty bound holds in the solution, the tank charges.
  - `test_sizing_factor1_invariant` extended with `H2TankCompressor` — scale-invariant under solve.
  - Full suite: 30 passed. All existing goldens byte-unchanged (compressor off everywhere).

  ## Not in this PR
  - Phase 2 (FCR-down bounded by compressor throughput) — its own re-baselined PR.
