### PR TITLE
feat: compressor-rate-gated FCR-down endurance (Phase 2)

### DIFF
--- a/data/sizing/make_sizing_cases.py
+++ b/data/sizing/make_sizing_cases.py
@@ -91,6 +91,11 @@ CASES = {
     # less, by the FCR revenue the electrolyser earns.
     "ElectrolyserNoFCR": dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10), h2_demand=0.5, e2h_fcr=False),
     "ElectrolyserFCR":   dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10), h2_demand=0.5, e2h_fcr=True),
+    # ElectrolyserFCR plus a sized compressor on the tank (PEMEL_01): exercises the Phase 2
+    # FCR-down rate coupling -- the electrolyser's FCR-down bid is bounded by the spare
+    # compressor throughput at the node, on top of the tank-headroom volume limit.
+    "ElectrolyserFCRCompressor": dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10),
+                                      h2_demand=0.5, e2h_fcr=True, compressor=("PEMEL_01", 2.0, 0.05)),
     # Three-state electrolyser demonstration: binary commitment, a small electrolyser, and
     # a hydrogen demand burst with a one-hour gap (0.09, 0, 0.09) and no storage buffer.
     # The electrolyser sits in STANDBY through the idle hour (drawing only its standby

--- a/docs/scope_electrolyser_compressor_sizing.md
+++ b/docs/scope_electrolyser_compressor_sizing.md
@@ -117,10 +117,14 @@ physically complete picture.
 
 - **Phase 1 (core):** duty bound + capex. Default-off, byte-unchanged, small and safe. Closes the
   el1xr feature gap so all three assets are sized.
-- **Phase 2 (optional, novelty):** the FCR-down rate coupling. Re-baselines the e2h FCR goldens with
-  justification (like the earlier Phase B re-baselines). This is where compressor sizing becomes a
-  contribution — Johnsen 2026 folds the compressor away entirely, and no reviewed paper gates FCR-down
-  by compressor throughput.
+- **Phase 2 (DONE, novelty):** the FCR-down rate coupling — `eEleFreqDownCompressorRate` in
+  oM_ModelFormulation. Per node and load level, the extra hydrogen a held FCR-down bid would make
+  (sum of DisDownward + Nor bids / ProductionFunction) plus the baseline charge must fit the built
+  compressor throughput. Gated on a node having BOTH FCR-flagged electrolysers and a compressor-sizing
+  candidate, so it is default-off byte-unchanged: the existing e2h FCR goldens are NOT re-baselined
+  (no shipped case combines compressor sizing with FCR). Demonstrated by the new
+  `ElectrolyserFCRCompressor` case (structural + solve tests). This is the contribution — Johnsen 2026
+  folds the compressor away entirely, and no reviewed paper gates FCR-down by compressor throughput.
 
 ## Novelty note
 

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -891,6 +891,27 @@ def create_constraints(model, optmodel, indlog):
         return lhs <= rhs
     optmodel.__setattr__('eEleFreqDownEnduranceConvEnd', Constraint(optmodel.psnnd, rule=eEleFreqDownEnduranceConvEnd, doc='Electrolyser FCR-down endurance for the terminal load level (C30)'))
 
+    # Phase 2 -- FCR-down bounded by the compressor RATE, not just the tank volume. The
+    # endurance constraints above limit the extra hydrogen by the empty tank headroom (a
+    # volume limit). A held FCR-down bid, if activated, also has to be COMPRESSED into the
+    # store as it is made: the extra production rate (bid / ProductionFunction) plus the
+    # baseline charge flow must fit through the built compressor throughput at the node.
+    # Only built when a node has both FCR-flagged electrolysers and a compressor-sizing
+    # candidate (model.hgcompc), so cases without compressor sizing are unchanged. Tying the
+    # FCR-down bid to the SIZED compressor rate is the part no reviewed prior work models
+    # (see docs/lit_review_electrolyser_fcr.md).
+    def eEleFreqDownCompressorRate(optmodel, p,sc,n,nd):
+        e2h_at_node = [e2h for e2h in model.e2h if (nd,e2h) in model.n2hg and (model.Par['pHydGenNoFCRD'][e2h] == 0 or model.Par['pHydGenNoFCRN'][e2h] == 0)]
+        comp_at_node = [hgs for hgs in model.hgcompc if (nd,hgs) in model.n2hg]
+        if not e2h_at_node or not comp_at_node:
+            return Constraint.Skip
+        lhs = sum((optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]
+                 + optmodel.vEleFreqContReserveNorBid       [p,sc,n,e2h]) / model.Par['pHydGenProductionFunction'][e2h] for e2h in e2h_at_node)
+        rhs = sum(model.Par['pHydGenCompressorNameplate'][hgs] * model.factor1 * optmodel.vHydCompInvest[hgs]
+                  - optmodel.vHydTotalCharge[p,sc,n,hgs] for hgs in comp_at_node)
+        return lhs <= rhs
+    optmodel.__setattr__('eEleFreqDownCompressorRate', Constraint(optmodel.psnnd, rule=eEleFreqDownCompressorRate, doc='Electrolyser FCR-down extra production rate bounded by spare node compressor throughput'))
+
     # print if the constraints object len is greater than 0
     if (len(optmodel.eEleFreqContReserveDisUpward) > 0 or len(optmodel.eEleFreqContReserveDisDownward) > 0 or
         len(optmodel.eEleRelationFreqDisUpBid2Gen) > 0 or len(optmodel.eEleRelationFreqDisDownBid2Gen) > 0 or

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -159,7 +159,8 @@ SIZING_CASES = [
 ]
 SIZING_CASE_NAMES = ["HomeBatt", "HoodBatt", "HomeBattNoTariff", "HomeBattNoFCR",
                      "HomeBattFCRDonly", "HomeBattFCRNonly", "H2Tank", "Electrolyser",
-                     "ElectrolyserStandby", "ElectrolyserFCR", "H2TankCompressor"]
+                     "ElectrolyserStandby", "ElectrolyserFCR", "H2TankCompressor",
+                     "ElectrolyserFCRCompressor"]
 SIZING_RTOL = 1e-5
 
 
@@ -265,6 +266,46 @@ def test_compressor_sizing_decision(sizing_cases_built):
             peak = max(peak, ch)
             assert ch <= built + 1e-4, f"charge {ch:.4f} exceeds built compressor throughput {built:.4f}"
     assert peak > 1e-3, f"tank never charged (peak {peak:.4f}), compressor sizing not exercised"
+
+
+def test_compressor_fcr_coupling_structure(sizing_cases_built):
+    """Phase 2: with both an FCR electrolyser and a sized compressor at a node, the FCR-down
+    rate coupling is built, tying the electrolyser's down-bids to the spare compressor
+    throughput (the built compressor rate minus the baseline charge flow)."""
+    from pyomo.core.expr.visitor import identify_variables
+
+    from el1xr_opt.Modules.oM_Sequence import build_model
+    m = build_model(sizing_cases_built, "ElectrolyserFCRCompressor",
+                    datetime.datetime.now().replace(second=0, microsecond=0))
+    assert "PEMEL_01" in m.hgcompc and "AEL_01" in m.e2h
+    assert len(m.eEleFreqDownCompressorRate) > 0
+    names = {v.name.split("[")[0]
+             for v in identify_variables(next(iter(m.eEleFreqDownCompressorRate.values())).body)}
+    assert "vEleFreqContReserveDisDownwardBid" in names
+    assert "vEleFreqContReserveNorBid" in names
+    assert "vHydCompInvest" in names
+    assert "vHydTotalCharge" in names
+
+
+@pytest.mark.solve
+def test_compressor_fcr_coupling_solves(sizing_cases_built):
+    """Phase 2 end to end: the combined FCR + compressor-sizing case solves, the compressor
+    is built, the FCR-down rate constraint is active, and it holds in the solution (the extra
+    production a held down-bid would make fits the spare compressor throughput at the node)."""
+    model = routine(dir=sizing_cases_built, case="ElectrolyserFCRCompressor", solver="highs",
+                    date=datetime.datetime.now().replace(second=0, microsecond=0),
+                    rawresults="False", plots="False", indlog="False", duckdbresults="False")
+    assert model is not None
+    assert model.vHydCompInvest["PEMEL_01"]() > 0.0, "compressor not built"
+    assert len(model.eEleFreqDownCompressorRate) > 0
+    # every rate-constraint row is satisfied in the solution
+    for idx in model.eEleFreqDownCompressorRate:
+        con = model.eEleFreqDownCompressorRate[idx]
+        body = pyo.value(con.body)
+        if con.upper is not None:
+            assert body <= float(pyo.value(con.upper)) + 1e-4
+        if con.lower is not None:
+            assert body >= float(pyo.value(con.lower)) - 1e-4
 
 
 @pytest.mark.solve


### PR DESCRIPTION
  ## Summary
  Phase 2 of compressor sizing: couples the electrolyser's FCR-down bid to the **rate** of the sized compressor, not just the tank volume.

  The existing endurance constraint limits FCR-down by the empty tank headroom (a volume limit).
  A held FCR-down bid, if activated, must also be compressed into the store as it is made. The new constraint `eEleFreqDownCompressorRate` enforces, per node and load level, that the extra production from the down-bid plus the baseline charge fits the built compressor throughput:

    Σ_{e2h@node} (DisDownward + Nor bids) / ProductionFunction ≤ Σ_{compressor@node} (nameplate · factor1 · vHydCompInvest − vHydTotalCharge)

  - **Gated** on a node having both FCR-flagged electrolysers and a compressor-sizing candidate, so it is default-off and byte-unchanged. No existing e2h FCR golden is re-baselined.
  - New `ElectrolyserFCRCompressor` case demonstrates it.

  This is the contribution dimension: Johnsen 2026 folds the compressor away entirely, and no reviewed paper gates FCR-down by compressor throughput (see docs/lit_review_electrolyser_fcr.md).

  ## Tests
  - `test_compressor_fcr_coupling_structure` — the constraint ties the down-bids, vHydCompInvest, and vHydTotalCharge.
  - `test_compressor_fcr_coupling_solves` (solve) — the combined case solves, the compressor is built, and every rate-constraint row holds.
  - Full suite: 32 passed. Existing goldens byte-unchanged.