### PR TITLE
fix: make Electrolyser-FCR cases feasible and solve them reliably (supersedes #146)

### DIFF
--- a/data/sizing/make_sizing_cases.py
+++ b/data/sizing/make_sizing_cases.py
@@ -85,17 +85,24 @@ CASES = {
     # making hydrogen from retail electricity beats the import price.
     "Electrolyser":     dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10),
                              h2_import=True, green=0),
-    # Electrolyser FCR validation: a small (feasible) hydrogen demand keeps the
-    # electrolyser running, so it has consumption to modulate. The NoFCR case is the
-    # baseline; the FCR case lets the electrolyser bid FCR. The FCR case should cost
-    # less, by the FCR revenue the electrolyser earns.
-    "ElectrolyserNoFCR": dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10), h2_demand=0.5, e2h_fcr=False),
-    "ElectrolyserFCR":   dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10), h2_demand=0.5, e2h_fcr=True),
+    # Electrolyser FCR validation: a hydrogen demand keeps the electrolyser running, so it
+    # has consumption to modulate. The NoFCR case is the baseline; the FCR case lets the
+    # electrolyser bid FCR. The FCR case should cost less, by the FCR revenue the
+    # electrolyser earns. A priced hydrogen import backs the demand: the electrolyser sits
+    # at Node2, which only has local solar for electricity, so it cannot make the full
+    # 0.5 kgH2/h on its own. Without the import the demand is unservable and the case is
+    # infeasible. Green-H2 matching stays on here so the matching structure is testable.
+    "ElectrolyserNoFCR": dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10), h2_demand=0.5, e2h_fcr=False, h2_import=True),
+    "ElectrolyserFCR":   dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10), h2_demand=0.5, e2h_fcr=True, h2_import=True),
     # ElectrolyserFCR plus a sized compressor on the tank (PEMEL_01): exercises the Phase 2
     # FCR-down rate coupling -- the electrolyser's FCR-down bid is bounded by the spare
     # compressor throughput at the node, on top of the tank-headroom volume limit.
+    # green=0 here so the electrolyser can draw grid electricity and run hard enough to
+    # hold real FCR-down bids; with matching on (and all solar dropped in this single-period
+    # run) its consumption is pinned near zero and the FCR-down coupling is never exercised.
     "ElectrolyserFCRCompressor": dict(battery=None, fcrd=True, fcrn=True, h2=("AEL_01", 0.10),
-                                      h2_demand=0.5, e2h_fcr=True, compressor=("PEMEL_01", 2.0, 0.05)),
+                                      h2_demand=0.5, e2h_fcr=True, compressor=("PEMEL_01", 2.0, 0.05),
+                                      green=0, h2_import=True),
     # Three-state electrolyser demonstration: binary commitment, a small electrolyser, and
     # a hydrogen demand burst with a one-hour gap (0.09, 0, 0.09) and no storage buffer.
     # The electrolyser sits in STANDBY through the idle hour (drawing only its standby

--- a/src/el1xr_opt/Modules/oM_Investment.py
+++ b/src/el1xr_opt/Modules/oM_Investment.py
@@ -170,6 +170,20 @@ def create_investment(model, optmodel, indlog):
         return optmodel.vHydTotalCharge[p, sc, n, hgcompc] <= model.Par['pHydGenCompressorNameplate'][hgcompc] * model.factor1 * optmodel.vHydCompInvest[hgcompc]
     optmodel.__setattr__('eHydInvestMaxCompressor', Constraint(psnhgcompc, rule=eHydInvestMaxCompressor, doc='candidate hydrogen compressor throughput limited by build decision'))
 
+    # Compressor build tied to its tank build. A compressor raises the hydrogen to the
+    # tank's storage pressure and injects it, so building a compressor only makes sense if
+    # the tank it feeds is built. When that tank is ITSELF an investment candidate, the
+    # compressor build fraction cannot exceed the tank build fraction (no compressor on a
+    # tank that was not built). The coupling is only added when the tank is a candidate
+    # (hgcompc unit also in hgc); a compressor sitting on an existing tank, or feeding a
+    # standalone high-pressure demand, keeps its own free build decision -- there is no
+    # blanket "no tank => no compressor" rule, since high-pressure delivery (tube-trailer,
+    # refuelling, pipeline injection) can need compression without on-site storage.
+    hgcompc_with_candidate_tank = [hgs for hgs in model.hgcompc if hgs in model.hgc]
+    def eHydCompInvestLink(optmodel, hgs):
+        return optmodel.vHydCompInvest[hgs] <= optmodel.vHydGenInvest[hgs]
+    optmodel.__setattr__('eHydCompInvestLink', Constraint(hgcompc_with_candidate_tank, rule=eHydCompInvestLink, doc='compressor build cannot exceed the build of the candidate tank it feeds'))
+
     # %% Total investment cost
     # Unit scaling: model.factor1 is the conversion factor that lets the model work
     # at either utility (MWh) or local/home (kWh) scale. It is applied to the

--- a/src/el1xr_opt/Modules/oM_ProblemSolving.py
+++ b/src/el1xr_opt/Modules/oM_ProblemSolving.py
@@ -141,7 +141,19 @@ def solving_model(DirName, CaseName, SolverName, optmodel, pWriteLP, indlog):
         # Solver.options["log_file"]             = os.path.join(_path, f"oM_{CaseName}.log")
         # Solver.options["log_to_console"]         = True
         Solver.options["presolve"]               = "on"
-        Solver.options["solver"]               = "ipm"
+        # Use simplex (not the interior-point method) as the LP algorithm. On these
+        # home/community-scale LPs simplex is fast AND it reports infeasibility quickly
+        # and reliably. The interior-point path could not cleanly prove infeasibility on a
+        # near-infeasible model: it ran out the whole time limit and returned a
+        # tolerance-violating pseudo-solution, which then read as a (wrong) "feasible"
+        # answer downstream. Simplex flags the same model infeasible in a fraction of a
+        # second.
+        Solver.options["solver"]               = "simplex"
+        # Scale the constraint matrix before solving. The model spans a wide coefficient
+        # range (operating costs ~1, the value-of-lost-load penalty ~1e5, efficiency and
+        # reserve-block terms ~1e-3), so explicit equilibration scaling tightens the
+        # conditioning and reduces solver tolerance warnings.
+        Solver.options["simplex_scale_strategy"] = 2
         Solver.options["parallel"]             = "on"
         Solver.options["run_crossover"]        = "on"  # HiGHS allows on/off only
         Solver.options["mip_rel_gap"]          = 0.02  # equivalent to MIPGap
@@ -183,6 +195,15 @@ def solving_model(DirName, CaseName, SolverName, optmodel, pWriteLP, indlog):
 
     SolverResults.write()  # summary of results
     optmodel.SolverResults1 = SolverResults
+
+    # Surface a non-optimal solve loudly. A solver that stops infeasible, or hits the time
+    # or iteration limit, leaves the model holding a meaningless (or only partially solved)
+    # point; using those values silently is how an infeasible case looked like a feasible
+    # one. Warn clearly so callers and tests see it rather than trusting the variables.
+    _tc = SolverResults.solver.termination_condition
+    if _tc != TerminationCondition.optimal:
+        print(f"WARNING: solver did not reach an optimal solution (termination: {_tc}); "
+              f"the model variable values may be meaningless. Check feasibility and limits.")
 
     # %% fix values of binary variables to get dual variables and solve it again
     print('# ============================================================================= #')

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -268,6 +268,28 @@ def test_compressor_sizing_decision(sizing_cases_built):
     assert peak > 1e-3, f"tank never charged (peak {peak:.4f}), compressor sizing not exercised"
 
 
+def test_compressor_tied_to_candidate_tank(sizing_cases_built):
+    """A compressor only makes sense if the tank it injects into is built. When that tank
+    is itself an investment candidate (H2TankCompressor: PEMEL_01 is both), the build
+    coupling vHydCompInvest <= vHydGenInvest is added. When the compressor sits on an
+    EXISTING tank (ElectrolyserFCRCompressor: the candidate is the electrolyser, the tank
+    exists), no coupling row is built -- the compressor keeps its own free build decision."""
+    from pyomo.core.expr.visitor import identify_variables
+
+    from el1xr_opt.Modules.oM_Sequence import build_model
+    date = datetime.datetime.now().replace(second=0, microsecond=0)
+
+    m = build_model(sizing_cases_built, "H2TankCompressor", date)
+    assert len(m.eHydCompInvestLink) == 1, "coupling expected when the tank is a candidate"
+    row = next(iter(m.eHydCompInvestLink.values()))
+    names = {v.name.split("[")[0] for v in identify_variables(row.body)}
+    assert "vHydCompInvest" in names and "vHydGenInvest" in names
+
+    m2 = build_model(sizing_cases_built, "ElectrolyserFCRCompressor", date)
+    assert len(m2.eHydCompInvestLink) == 0, \
+        "no coupling expected when the compressor sits on an existing tank"
+
+
 def test_compressor_fcr_coupling_structure(sizing_cases_built):
     """Phase 2: with both an FCR electrolyser and a sized compressor at a node, the FCR-down
     rate coupling is built, tying the electrolyser's down-bids to the spare compressor
@@ -538,6 +560,22 @@ def test_electrolyser_fcr_structure(sizing_cases_built):
     bid = model.vEleFreqContReserveDisUpwardBid
     e2h_bids = [bid[idx] for idx in bid if idx[-1] == u]
     assert e2h_bids and not any(v.fixed for v in e2h_bids)
+
+
+@pytest.mark.solve
+def test_electrolyser_fcr_solves(sizing_cases_built):
+    """Base ElectrolyserFCR solves to a sane (small) objective. This is the regression
+    guard the missing solve test would have caught: the case was infeasible (no hydrogen
+    import to back the demand) and the solver only returned a penalty-laden pseudo-solution,
+    which surfaced later as the compressor case failing to build the compressor."""
+    model = routine(dir=sizing_cases_built, case="ElectrolyserFCR", solver="highs",
+                    date=datetime.datetime.now().replace(second=0, microsecond=0),
+                    rawresults="False", plots="False", indlog="False", duckdbresults="False")
+    assert model is not None
+    # the electrolyser FCR endurance path is built and the solve is feasible (a real cost,
+    # not the large penalty value an infeasible case returns)
+    assert len(model.eEleFreqDownEnduranceConv) > 0
+    assert 0.0 < float(pyo.value(model.eTotalSCost)) < 1.0e4
 
 
 @pytest.mark.solve


### PR DESCRIPTION
  ## What this fixes

  `test_compressor_fcr_coupling_solves` (case `ElectrolyserFCRCompressor`) failed in CI: the
  solver hit its time limit and left the compressor unbuilt. The real problem was not the
  compressor economics — the case was **infeasible**.

  ## Root cause

  The electrolyser sits at a node whose only electricity source is local solar, and the
  Electrolyser-FCR cases had no hydrogen import to back their demand, so the hydrogen demand
  could not be served. On top of that, green-H2 matching was left on while all solar units
  are dropped in the single-period run (their start year is later than the base year), which
  pins the electrolyser's consumption near zero.

  The interior-point solver could not prove this infeasibility cleanly: it ran out the time
  limit and returned a penalty-laden point that looked feasible downstream, so the test saw a
  "solved" model with no compressor. Plain simplex flags the same model infeasible in a
  fraction of a second.

  This slipped through because there was no solve test for the base `ElectrolyserFCR` case —
  only the new compressor case was solved in CI.

  ## Changes

  1. **Cases** (`make_sizing_cases.py`): add a priced hydrogen import to the Electrolyser-FCR
     cases so the demand can be met (the pattern the working `Electrolyser`/`H2Tank` cases
     already use). Disable green-H2 matching on the compressor case so the electrolyser can
     draw grid power and hold real FCR-down bids; matching stays on for `ElectrolyserFCR` so
     its structure is still tested.
  2. **Investment** (`oM_Investment.py`): a compressor only makes sense if the tank it feeds
     is built, so when that tank is itself an investment candidate, couple the builds:
     `vHydCompInvest <= vHydGenInvest` (`eHydCompInvestLink`). A compressor on an existing
     tank keeps its own free build decision. The inequality is deliberate — it still allows a
     small, cheaper compressor on a larger tank, which the existing throughput bound intends.
  3. **Solver** (`oM_ProblemSolving.py`): use simplex instead of the interior-point method on
     the HiGHS path (fast here, and it reports infeasibility quickly), add matrix scaling for
     the wide coefficient range, and warn loudly when a solve does not reach an optimal
     solution instead of using meaningless values silently.
  4. **Tests**: add a solve test for base `ElectrolyserFCR` (the regression guard that was
     missing) and a structural test for the compressor-tank coupling.

  ## Relationship to #146

  This supersedes #146, which targeted the same failure but did not fix the underlying
  infeasibility (so its CI still fails). #146 raised the HiGHS time limit to 1200 s, which
  only waits out the slow solve on an infeasible model; this PR removes the need for that by
  switching to simplex. #146 also linked the compressor to the tank with an equality
  (`vHydCompInvest == vHydGenInvest`), which forbids a small compressor on a large tank; this
  PR uses an inequality instead. The link constraint keeps the name `eHydCompInvestLink` for
  continuity.

  ## Validation

  - Full `test_run.py` solve suite: 28 passed in ~31 s (previously a 1200 s timeout on the one
    test).
  - Golden costs unchanged (`home1`, `grid1`, `eem26`, `h2vpp`).
  - benders / heat / community solve suites: 27 passed. formulation / lindist / problem-class:
    passed.

