### PR TITLE
Fix factor1 scaling of not-served penalty prices, plus factor1 input hook, per-demand H2 price, and Gurobi robustness

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -111,6 +111,14 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     # (guarded by test_factor1_invariant). FACTOR1 (module global) is the override hook for
     # that test and the future dfParameter input.
     factor1 = FACTOR1
+    # Optional per-case override from a 'Factor1' column in the Parameter input, for
+    # numerical conditioning at different scales without a code change (the optimum is
+    # invariant -- see test_factor1_invariant). Falls back to the module default when
+    # absent or blank. (_f1 == _f1 is False only for NaN, so it skips empty cells.)
+    if 'Factor1' in data_frames['dfParameter'].columns:
+        _f1 = data_frames['dfParameter']['Factor1'].iloc[0]
+        if _f1 == _f1 and float(_f1) > 0:
+            factor1 = float(_f1)
     # factor2 (the old 1e-3 commitment-cost unit bridge) is ELIMINATED (audit Phase B / B0):
     # the model now works in a single canonical currency, so ConstantTerm / StartUpCost /
     # ShutDownCost are entered directly in that currency (no hidden scaling). See the
@@ -133,7 +141,19 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
 
     # Extract, process parameter variables and add to parameters_dict
     for indicator in parameter_ind:
-        if ('Cost' in indicator or 'Target' in indicator or 'Ramp' in indicator) and 'CO2' not in indicator:
+        if 'CO2' in indicator:
+            # CO2Cost is carried unscaled here; the 1/factor1 is applied via the emission
+            # rate at the use site (pGenCO2EmissionCost), so do not scale it twice.
+            parameters_dict[f'pPar{indicator}'] = data_frames['dfParameter'][indicator].iloc[0]
+        elif 'Cost' in indicator:
+            # ENSCost / HNSCost are per-quantity PENALTY PRICES (cost per unserved kWh/kg)
+            # multiplying the extensive vENS/vHNS (which carry factor1), so they carry
+            # 1/factor1 -- NOT factor1 -- to keep the penalty cost invariant (audit C38).
+            # They were previously lumped with Target/Ramp and scaled by factor1, which made
+            # the not-served penalty off by factor1**2 (latent only while ENS/HNS == 0).
+            parameters_dict[f'pPar{indicator}'] = data_frames['dfParameter'][indicator].iloc[0] / factor1
+        elif 'Target' in indicator or 'Ramp' in indicator:
+            # extensive quantities (demand target, ramp limit) carry factor1
             parameters_dict[f'pPar{indicator}'] = data_frames['dfParameter'][indicator].iloc[0] * factor1
         else:
             parameters_dict[f'pPar{indicator}'] = data_frames['dfParameter'][indicator].iloc[0]
@@ -217,6 +237,12 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
                       'RampUp', 'RampDown', 'MaxOutflowsProd', 'MinOutflowsProd', 'MaxInflowsCons', 'MinInflowsCons', 'OutflowsRampDown', 'OutflowsRampUp']
     # demand indicators
     EleDemand_ind = data_frames['dfElectricityDemand'].columns.to_list()
+    # Per-demand hydrogen price (sale price / willingness-to-pay, currency/kgH2). An
+    # optional 'Price' column; default 0 leaves existing cases unchanged. Read into
+    # pHydDemPrice and credited as revenue for served demand in the objective
+    # (eTotalHydRCost), so different sectors can be sold at different prices.
+    if 'Price' not in data_frames['dfHydrogenDemand'].columns:
+        data_frames['dfHydrogenDemand']['Price'] = 0.0
     HydDemand_ind = data_frames['dfHydrogenDemand'].columns.to_list()
     idx_dem_factoring = ['MaximumPower']
 
@@ -234,6 +260,10 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     _update_parameters(data_frames, parameters_dict, factor1, HydGeneration_ind, idx_gen_factoring, 'dfHydrogenGeneration', 'pHydGen')
     _update_parameters(data_frames, parameters_dict, factor1, HydDemand_ind, idx_dem_factoring, 'dfHydrogenDemand', 'pHydDem')
     _update_parameters(data_frames, parameters_dict, factor1, HydRetail_ind, idx_retail_factoring, 'dfHydrogenRetail', 'pHydRet')
+    # The per-demand hydrogen price is a per-quantity PRICE, so it carries 1/factor1
+    # (audit C38), like the energy and FCR prices: the served quantity (vHydDemand)
+    # scales by factor1, so price x quantity (the revenue) stays invariant.
+    parameters_dict['pHydDemPrice'] = parameters_dict['pHydDemPrice'] / factor1
 
     # Per-step buy/sell caps (MaxBuy/MaxSell) are optional retail columns. When a
     # retail file omits them, default the cap to 0.0, read as "no cap" by the

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -259,11 +259,18 @@ def create_objective_function_components(model, optmodel, indlog):
         return optmodel.vTotalHydCCost[p,sc,n] == sum(model.Par['pHydGenLinearTerm'][hgs] * optmodel.vHydTotalCharge[p,sc,n,hgs] for hgs in model.hgs)
     optmodel.__setattr__('eTotalHydCCost', Constraint(optmodel.psn, rule=eTotalHydCCost, doc='Total consumption cost in hydrogen units [kEUR]'))
 
-    # Hydrogen reliability cost [M€]
+    # Hydrogen reliability cost [M€], net of per-demand sale revenue.
     def eTotalHydRCost(optmodel, p,sc,n):
         # Hydrogen not served: same fix as the electricity reliability cost above --
         # the psn aggregation supplies the single duration weight. See docs/model_audit.md.
-        return (optmodel.vTotalHydRCost[p,sc,n] == sum(model.Par['pParHNSCost'] * optmodel.vHNS[p,sc,n,hd] for hd in model.hd))
+        # Per-demand price (pHydDemPrice, default 0): the served quantity
+        # (vHydDemand - vHNS) earns the demand's own price as REVENUE, so different
+        # consumer sectors can be sold hydrogen at different prices. With price 0 this
+        # reduces to the original not-served penalty (existing cases unchanged).
+        return (optmodel.vTotalHydRCost[p,sc,n] == sum(
+            model.Par['pParHNSCost'] * optmodel.vHNS[p,sc,n,hd]
+            - model.Par['pHydDemPrice'][hd] * (optmodel.vHydDemand[p,sc,n,hd] - optmodel.vHNS[p,sc,n,hd])
+            for hd in model.hd))
     optmodel.__setattr__('eTotalHydRCost', Constraint(optmodel.psn, rule=eTotalHydRCost, doc='Total reliability cost in hydrogen consumers [kEUR]'))
 
     log_time('--- Declaring the ObjFunc components:', StartTime, ind_log=indlog)

--- a/src/el1xr_opt/Modules/oM_ProblemSolving.py
+++ b/src/el1xr_opt/Modules/oM_ProblemSolving.py
@@ -126,10 +126,14 @@ def solving_model(DirName, CaseName, SolverName, optmodel, pWriteLP, indlog):
         Solver.options["MIPFocus"]        = 1
         Solver.options["Presolve"]        = 2
         Solver.options["RINS"]            = 100
-        Solver.options["Crossover"]       = -1
+        Solver.options["Crossover"]       = -1         # skip crossover: the kW-scale model with
+                                                       # tight must-serve equalities makes crossover
+                                                       # numerically declare a feasible barrier
+                                                       # optimum "infeasibleOrUnbounded"
+        Solver.options["BarHomogeneous"]  = 1          # robust infeasible/unbounded detection
         # Solver.options["FeasibilityTol"]  = 1e-9
         Solver.options["FeasibilityTol"]  = 1e-8
-        Solver.options["NumericFocus"]    = 1
+        Solver.options["NumericFocus"]    = 3
         Solver.options["MIPGap"]          = 0.02
         Solver.options["Threads"]         = int((psutil.cpu_count(True) + psutil.cpu_count(False)) / 2)
         Solver.options["TimeLimit"]       = 1000

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1154,6 +1154,30 @@ def test_factor1_default_is_one(h2_model):
     assert _ID.FACTOR1 == 1.0, "the FACTOR1 module-global default must be 1.0"
 
 
+def test_not_served_penalty_price_scaled_by_inverse_factor1():
+    """C38: ENSCost / HNSCost are per-quantity penalty PRICES (cost per unserved kWh / kg)
+    multiplying the extensive vENS / vHNS (which carry factor1), so they must be read with
+    1/factor1 -- like every other price -- to keep the not-served penalty cost invariant.
+    They were originally lumped into the same branch as the extensive Target / Ramp quantities
+    and scaled by factor1, which made the penalty off by factor1**2. The bug was latent only
+    because vENS == vHNS == 0 whenever all demand is served, so it never showed in the
+    all-served goldens; it distorts the penalty the moment a firm contract leaves demand
+    unserved. CO2Cost stays unscaled here (it is scaled via the emission rate at the use site).
+    Checked at the source: the read-scaling loop must split Cost (/factor1) from Target/Ramp
+    (*factor1)."""
+    text = open(INPUT_DATA, encoding="utf-8").read()
+    start = text.index("Extract, process parameter variables")
+    body = text[start:text.index("Currency label", start)]
+    assert "'Cost' in indicator" in body and "/ factor1" in body, \
+        "the per-quantity Cost penalty prices (ENSCost/HNSCost) must be read with 1/factor1 (C38)"
+    assert "'Target' in indicator or 'Ramp' in indicator" in body and "* factor1" in body, \
+        "the extensive Target/Ramp quantities must stay on the *factor1 branch (C38)"
+    # the Cost branch must divide; it must not be the multiply branch any more
+    cost_branch = body[body.index("elif 'Cost' in indicator"):body.index("elif 'Target'")]
+    assert "/ factor1" in cost_branch and "* factor1" not in cost_branch, \
+        "the Cost branch must divide by factor1, not multiply (C38)"
+
+
 @pytest.mark.solve
 def test_factor1_invariant():
     """C38: factor1 is a TRUE unit conversion -- it scales extensive quantities by factor1 and


### PR DESCRIPTION
  ## What this does

  Four related changes, all from the 2026-06 factor1 audit.

  ### 1. Fix: not-served penalty prices were mis-scaled by factor1 (main fix)
  `ENSCost` and `HNSCost` are per-quantity penalty prices (cost per unserved
  kWh / kg), so they must be read with 1/factor1 like every other price. They
  were lumped into the same branch as the extensive `Target` / `Ramp`
  quantities and multiplied by factor1, which made the not-served penalty off
  by factor1 squared.

  The bug was latent while all demand is served (`vENS == vHNS == 0`), so it
  never showed in the all-served goldens. It distorts the penalty the moment a
  firm contract leaves demand unserved. The read-scaling branch is now split:
  `Cost` divides by factor1, `Target`/`Ramp` multiply by factor1, and `CO2`
  stays unscaled (it is scaled via the emission rate at its use site).

  ### 2. factor1 input hook
  factor1 can now be set per case from an optional `Factor1` column in the
  Parameter input, with the module default as the fallback. This lets a case
  pick its unit scale (e.g. an MW basis at 0.001) for better conditioning
  without a code change. At factor1 = 1 every scaling is a no-op, so existing
  goldens are unchanged.

  ### 3. Per-demand hydrogen price
  Hydrogen demand can carry an optional `Price` column (willingness to pay).
  Served demand earns that price as revenue in `eTotalHydRCost`, so different
  sectors can be sold at different prices. The price is read with 1/factor1
  like the other prices. Absent or zero leaves existing cases unchanged.

  ### 4. Gurobi robustness
  `BarHomogeneous = 1` and `NumericFocus = 3` for more reliable
  infeasible/unbounded detection on harder solves.

  ## Testing

  New regression test `test_not_served_penalty_price_scaled_by_inverse_factor1`
  pins the penalty-price read scaling. The full factor1 suite passes:

      pytest tests/test_formulation_fixes.py tests/test_run.py -k "factor1 or not_served_penalty"
      # 9 passed

  The model was also audited at factor1 = 1.0 vs 0.001 by comparing every
  parameter and every written LP coefficient: zero mis-scaled parameters, and
  the optimum is invariant. The penalty fix is the only behavioural change.
