### PR TITLE
Make golden-cost tests deterministic to fix flaky CI

### DIFF
--- a/src/el1xr_opt/Modules/oM_ProblemSolving.py
+++ b/src/el1xr_opt/Modules/oM_ProblemSolving.py
@@ -169,6 +169,17 @@ def solving_model(DirName, CaseName, SolverName, optmodel, pWriteLP, indlog):
         Solver.options["threads"]              = int((psutil.cpu_count(True) + psutil.cpu_count(False)) / 2)
         Solver.options["time_limit"]           = 150
         Solver.options["ipm_iteration_limit"]  = 1800000
+        # Deterministic mode for reproducible golden-cost tests. A parallel MILP returns a
+        # different within-the-gap incumbent depending on the thread count and HiGHS
+        # version, so a golden cost pinned to a tight tolerance flakes from one machine to
+        # another. When EL1XR_HIGHS_DETERMINISTIC is set, solve single-threaded to a zero
+        # MIP gap, so the returned objective is the proven optimum and is reproducible.
+        # Off by default, so production runs keep parallel solving and the 2% gap.
+        if os.environ.get("EL1XR_HIGHS_DETERMINISTIC", "").lower() in ("1", "true", "yes"):
+            Solver.options["parallel"]    = "off"
+            Solver.options["threads"]     = 1
+            Solver.options["mip_rel_gap"] = 0.0
+            Solver.options["mip_abs_gap"] = 0.0
         print("HiGHS solver options configured.")
 
     # ---- Solve ----

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+@pytest.fixture
+def deterministic_highs(monkeypatch):
+    """Force HiGHS to solve single-threaded to a zero MIP gap.
+
+    The golden-cost tests assert an exact objective to a tight tolerance. A parallel
+    MILP returns a different within-the-gap incumbent depending on the thread count
+    and the HiGHS version, so those assertions flake from one machine to another. With
+    this fixture the solve is deterministic and returns the proven optimum, which is
+    reproducible. See the EL1XR_HIGHS_DETERMINISTIC switch in oM_ProblemSolving.
+    """
+    monkeypatch.setenv("EL1XR_HIGHS_DETERMINISTIC", "1")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -76,7 +76,7 @@ def _assert_cost(actual, expected, rtol):
 
 @pytest.mark.solve
 @pytest.mark.parametrize("label,d,case,expected,rtol", CASES, ids=CASE_IDS)
-def test_cost_from_csv(label, d, case, expected, rtol):
+def test_cost_from_csv(label, d, case, expected, rtol, deterministic_highs):
     """Solve the case reading its CSV folder; check the golden cost."""
     with truncated_duration(d, case):
         model = routine(**_run_dict(d, case))
@@ -86,7 +86,7 @@ def test_cost_from_csv(label, d, case, expected, rtol):
 
 @pytest.mark.solve
 @pytest.mark.parametrize("label,d,case,expected,rtol", CASES, ids=CASE_IDS)
-def test_cost_from_duckdb(label, d, case, expected, rtol, tmp_path):
+def test_cost_from_duckdb(label, d, case, expected, rtol, tmp_path, deterministic_highs):
     """Solve the same (truncated) case from a .duckdb file; check the golden cost."""
     work = tmp_path / label
     os.makedirs(work / case)  # output folder for results
@@ -181,7 +181,7 @@ def sizing_cases_built():
 
 @pytest.mark.solve
 @pytest.mark.parametrize("case,expected", SIZING_CASES)
-def test_sizing_case_from_duckdb(case, expected, sizing_cases_built):
+def test_sizing_case_from_duckdb(case, expected, sizing_cases_built, deterministic_highs):
     """Solve each variant case from its generated .duckdb and check the golden cost."""
     model = routine(dir=sizing_cases_built, case=case, solver="highs",
                     date=datetime.datetime.now().replace(second=0, microsecond=0),


### PR DESCRIPTION
  ## Problem

  CI failed on `test_cost_from_csv[h2vpp]` and `test_cost_from_duckdb[h2vpp]`: the
  solved cost was 354.1300 against a golden of 354.0527 (relative difference 2.18e-4).
  That difference equals the solver's reported relative MIP gap exactly.

  The golden-cost tests assert an exact objective to `rtol=1e-6`, but the HiGHS MILP
  solves **in parallel** (`parallel=on`, multiple threads) to a **2% gap**. A parallel
  branch-and-bound returns a different within-the-gap incumbent depending on the thread
  count and the HiGHS version, so the assertion flakes from one machine to another. It
  surfaced on the CI runner (Windows, HiGHS 1.14.0, 3 threads); the same case passes on
  other machines. Both 354.1300 and 354.0527 are valid solutions within the 2% gap.

  ## Fix

  Add an `EL1XR_HIGHS_DETERMINISTIC` switch in `oM_ProblemSolving`. When set, HiGHS
  solves single-threaded (`parallel=off`, `threads=1`) to a zero MIP gap, so the
  returned objective is the proven optimum — reproducible across machines, thread
  counts, and HiGHS versions. It is off by default, so production runs keep parallel
  solving and the 2% gap.

  A new `tests/conftest.py` fixture turns the switch on for the three golden-cost tests
  (`test_cost_from_csv`, `test_cost_from_duckdb`, `test_sizing_case_from_duckdb`).

  ## Verification

  All 16 golden-cost cases pass under the deterministic fixture, reproducing the
  existing goldens — so the goldens are the true optima and no golden values change.
  The full suite still collects (149 tests).
