### PR TITLE
Add optional electrolyser degradation: load-dependent + cycling

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -296,6 +296,15 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         _df_gen_key = 'dfElectricityGeneration' if sector == 'Ele' else 'dfHydrogenGeneration'
         if f'p{sector[0:3]}GenDegradationCost' not in parameters_dict:
             parameters_dict[f'p{sector[0:3]}GenDegradationCost'] = pd.Series(0.0, index=data_frames[_df_gen_key].index)
+        # Load-dependent degradation surcharge (M2): an optional EXTRA stack-wear cost on the
+        # high-load (2nd-block) consumption; default zero so existing cases are unaffected.
+        if f'p{sector[0:3]}GenDegradationCost2ndBlock' not in parameters_dict:
+            parameters_dict[f'p{sector[0:3]}GenDegradationCost2ndBlock'] = pd.Series(0.0, index=data_frames[_df_gen_key].index)
+        # Cycling degradation cost (M2b): an optional stack-wear cost per kW of hour-to-hour
+        # change in productive consumption -- the FCR-modulation/cycling stress the throughput
+        # term misses; default zero so existing cases are unaffected.
+        if f'p{sector[0:3]}GenRampDegradationCost' not in parameters_dict:
+            parameters_dict[f'p{sector[0:3]}GenRampDegradationCost'] = pd.Series(0.0, index=data_frames[_df_gen_key].index)
         # factor1 (audit C38): per-quantity PRICES carry 1/factor1 so price x quantity (which
         # scales by factor1) is invariant. LinearVarCost, CO2EmissionCost and OMVariableCost are
         # such prices; the CO2 emission RATE is a dimensionless ratio and is no longer factored.
@@ -308,6 +317,11 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         # Degradation cost (audit Phase B / B2): a stack-wear PRICE per kWh of productive
         # electricity, so it carries 1/factor1 like the other per-quantity prices (default 0).
         parameters_dict[f'p{sector[0:3]}GenDegradationCost'   ] = parameters_dict[f'p{sector[0:3]}GenDegradationCost'     ] / model.factor1                                                                                                                        # stack degradation cost (price per kWh)
+        # M2: load-dependent degradation surcharge, a per-quantity price on the high-load
+        # (2nd-block) consumption, so it carries 1/factor1 like the other prices (default 0).
+        parameters_dict[f'p{sector[0:3]}GenDegradationCost2ndBlock'] = parameters_dict[f'p{sector[0:3]}GenDegradationCost2ndBlock'] / model.factor1
+        # M2b: cycling degradation, a per-quantity price on |delta consumption| -> 1/factor1 (default 0).
+        parameters_dict[f'p{sector[0:3]}GenRampDegradationCost'] = parameters_dict[f'p{sector[0:3]}GenRampDegradationCost'] / model.factor1
         parameters_dict[f'p{sector[0:3]}GenInvestCost'        ] = parameters_dict[f'p{sector[0:3]}GenFixedInvestmentCost' ]        * parameters_dict[f'p{sector[0:3]}GenFixedChargeRate']                                                                          # generation fixed cost                   [MEUR]
         parameters_dict[f'p{sector[0:3]}GenRetireCost'        ] = parameters_dict[f'p{sector[0:3]}GenFixedRetirementCost' ]        * parameters_dict[f'p{sector[0:3]}GenFixedChargeRate']                                                                          # generation fixed retirement cost        [MEUR]                                                                           # H2 outflows ramp down rate              [tonH2]
 
@@ -1213,7 +1227,19 @@ def create_variables(model, optmodel, indlog):
     setattr(optmodel, 'vEleDemPeakDay',                    Var(model.psder,   within=PositiveReals, doc='electricity daily peak                                                  [kW]'))
     setattr(optmodel, 'vHydDemPeakDay',                    Var(model.psdhr,   within=PositiveReals, doc='hydrogen    daily peak                                                [kgH2]'))
 
+    # M2b: cycling-degradation auxiliary variable, built only when any electrolyser carries a
+    # RampDegradationCost > 0, so default cases are byte-unchanged. Holds |delta productive
+    # consumption| (linearised in oM_ModelFormulation) and is priced in the generation cost.
+    model._ramp_deg_active = any(float(model.Par['pHydGenRampDegradationCost'][e2h]) > 0 for e2h in model.e2h)
+
     # Define continuous variables
+    if model._ramp_deg_active:
+        setattr(optmodel, 'vHydGenRampAbs',               Var(model.psne2h,  within=NonNegativeReals, doc='electrolyser |delta productive consumption| for cycling degradation [kW]'))
+        # the first load level has no previous hour, so its ramp is undefined -- fix to zero
+        # (no constraint, no cost) rather than leave a dangling variable.
+        for _idx in model.psne2h:
+            if _idx[2] == model.n.first():
+                optmodel.vHydGenRampAbs[_idx].fix(0.0)
     setattr(optmodel, 'vEleBuy',                           Var(model.psner,   within=NonNegativeReals, doc='electricity retail  buy                                                 [kW]'))
     setattr(optmodel, 'vEleSell',                          Var(model.psner,   within=NonNegativeReals, doc='electricity retail  sell                                                [kW]'))
     setattr(optmodel, 'vEleDemand',                        Var(model.psned,   within=NonNegativeReals, doc='electricity demand                                                      [kW]'))

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -239,8 +239,33 @@ def create_objective_function_components(model, optmodel, indlog):
                                                    # Degradation (audit Phase B / B2): stack-wear cost per kWh of PRODUCTIVE electricity
                                                    # (input minus the standby draw, which makes no hydrogen) -- the real cost of flexible
                                                    # operation, amortising stack replacement over throughput. Zero for non-electrolysers.
-                                                   sum(model.Par['pHydGenDegradationCost'][e2h] * (optmodel.vEleTotalCharge[p,sc,n,e2h] - model.Par['pHydGenStandByPower'][e2h] * optmodel.vHydGenStandBy[p,sc,n,e2h]) for e2h in model.e2h))
+                                                   sum(model.Par['pHydGenDegradationCost'][e2h] * (optmodel.vEleTotalCharge[p,sc,n,e2h] - model.Par['pHydGenStandByPower'][e2h] * optmodel.vHydGenStandBy[p,sc,n,e2h]) for e2h in model.e2h) +
+                                                   # M2: load-dependent degradation surcharge -- an EXTRA stack-wear cost on the high-load
+                                                   # (2nd-block) consumption, a piecewise-linear stand-in for the current-density-dependent
+                                                   # voltage rise (the stack degrades faster at higher load, so flexing up for FCR-down and
+                                                   # running hard costs more than throughput alone implies). Zero by default (audit M2).
+                                                   sum(model.Par['pHydGenDegradationCost2ndBlock'][e2h] * optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h] for e2h in model.e2h) +
+                                                   # M2b: cycling-degradation cost on |delta productive consumption| (the FCR-modulation stress
+                                                   # the throughput term misses); active only when a unit carries RampDegradationCost > 0.
+                                                   (sum(model.Par['pHydGenRampDegradationCost'][e2h] * optmodel.vHydGenRampAbs[p,sc,n,e2h] for e2h in model.e2h) if getattr(model, '_ramp_deg_active', False) and n != model.n.first() else 0))
     optmodel.__setattr__('eTotalHydGCost', Constraint(optmodel.psn, rule=eTotalHydGCost, doc='Total hydrogen generation cost [kEUR]'))
+
+    # M2b: linearise |delta productive consumption| for the electrolyser cycling-degradation cost.
+    # productive consumption = vEleTotalCharge - StandByPower * vHydGenStandBy; vHydGenRampAbs >=
+    # |prod[n] - prod[n-1]| via the two one-sided constraints. Built only when active.
+    if getattr(model, '_ramp_deg_active', False):
+        def _prod(optmodel, p, sc, n, e2h):
+            return optmodel.vEleTotalCharge[p,sc,n,e2h] - model.Par['pHydGenStandByPower'][e2h] * optmodel.vHydGenStandBy[p,sc,n,e2h]
+        def eHydRampDegradationUp(optmodel, p, sc, n, e2h):
+            if n == model.n.first():
+                return Constraint.Skip
+            return optmodel.vHydGenRampAbs[p,sc,n,e2h] >= _prod(optmodel,p,sc,n,e2h) - _prod(optmodel,p,sc,model.n.prev(n),e2h)
+        optmodel.__setattr__('eHydRampDegradationUp', Constraint(optmodel.psne2h, rule=eHydRampDegradationUp, doc='electrolyser cycling: ramp-abs >= +delta consumption [kW]'))
+        def eHydRampDegradationDn(optmodel, p, sc, n, e2h):
+            if n == model.n.first():
+                return Constraint.Skip
+            return optmodel.vHydGenRampAbs[p,sc,n,e2h] >= _prod(optmodel,p,sc,model.n.prev(n),e2h) - _prod(optmodel,p,sc,n,e2h)
+        optmodel.__setattr__('eHydRampDegradationDn', Constraint(optmodel.psne2h, rule=eHydRampDegradationDn, doc='electrolyser cycling: ramp-abs >= -delta consumption [kW]'))
 
     # Hydrogen start-up / shut-down cost [M€] -- per-event, summed over the load levels
     # WITHOUT pDuration (a 'ps' objective term). The e2h start-up and shut-down terms cover an

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1154,6 +1154,43 @@ def test_factor1_default_is_one(h2_model):
     assert _ID.FACTOR1 == 1.0, "the FACTOR1 module-global default must be 1.0"
 
 
+def test_electrolyser_load_degradation_surcharge():
+    """M2: an optional load-dependent stack-degradation surcharge costs the high-load
+    (2nd-block) electrolyser consumption -- a piecewise-linear stand-in for the
+    current-density-dependent voltage rise, so FCR-down/high-load operation costs more than
+    throughput alone implies. It is a per-quantity PRICE (read with 1/factor1) and defaults
+    to zero (byte-unchanged goldens). Checked at the source."""
+    obj = open(MODEL_FORMULATION, encoding="utf-8").read()
+    assert "pHydGenDegradationCost2ndBlock" in obj and "vEleTotalCharge2ndBlock" in obj, \
+        "eTotalHydGCost must add the 2nd-block load-degradation surcharge (M2)"
+    # oM_InputData builds the name per sector via an f-string (p{sector}GenDegradation...),
+    # so match the suffix, and check it is read with 1/factor1 and defaults to zero.
+    src = open(INPUT_DATA, encoding="utf-8").read()
+    assert "GenDegradationCost2ndBlock'] = parameters_dict[f'p{sector[0:3]}GenDegradationCost2ndBlock'] / model.factor1" in src, \
+        "the load-degradation surcharge is a price -> read with 1/factor1 (M2)"
+    assert "GenDegradationCost2ndBlock'] = pd.Series(0.0" in src, \
+        "the surcharge must default to zero when the column is absent (M2)"
+
+
+def test_electrolyser_cycling_degradation_optional():
+    """M2b: an optional cycling-degradation cost on |delta productive consumption| captures the
+    FCR-modulation stress the throughput term misses. It is built only when a unit carries
+    RampDegradationCost > 0 (so default cases are byte-unchanged), linearised by two one-sided
+    ramp constraints, priced as a 1/factor1 per-quantity cost, and the first load level is fixed
+    to zero. Checked at the source."""
+    obj = open(MODEL_FORMULATION, encoding="utf-8").read()
+    assert "pHydGenRampDegradationCost" in obj and "vHydGenRampAbs" in obj, \
+        "eTotalHydGCost must add the cycling-degradation term (M2b)"
+    assert "eHydRampDegradationUp" in obj and "eHydRampDegradationDn" in obj, \
+        "the |delta| must be linearised by two one-sided ramp constraints (M2b)"
+    assert "_ramp_deg_active" in obj, "the cycling term must be guarded (built only when active) (M2b)"
+    src = open(INPUT_DATA, encoding="utf-8").read()
+    assert "model._ramp_deg_active = any(" in src and "vHydGenRampAbs" in src, \
+        "the ramp-abs variable must be built only when a unit has RampDegradationCost > 0 (M2b)"
+    assert "GenRampDegradationCost'] = pd.Series(0.0" in src, \
+        "the cycling cost must default to zero when the column is absent (M2b)"
+
+
 def test_not_served_penalty_price_scaled_by_inverse_factor1():
     """C38: ENSCost / HNSCost are per-quantity penalty PRICES (cost per unserved kWh / kg)
     multiplying the extensive vENS / vHNS (which carry factor1), so they must be read with


### PR DESCRIPTION
  Two optional, default-off stack-degradation costs for electrolysers, so the
  throughput-only cost no longer under-states the wear of flexible/FCR operation:
   - load-dependent surcharge on high-load (2nd-block) consumption (M2), a piecewise stand-in for the current-density-dependent voltage rise;
   - cycling cost on the hour-to-hour change in productive consumption (M2b), linearised by two one-sided ramp constraints, built only when active. Both default to zero (goldens byte-unchanged) and are read with 1/factor1.