### PR TITLE
Add optional hydrogen demand volume quota

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -265,6 +265,20 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     # scales by factor1, so price x quantity (the revenue) stays invariant.
     parameters_dict['pHydDemPrice'] = parameters_dict['pHydDemPrice'] / factor1
 
+    # Optional hydrogen demand volume quota. pHydDemQuotaSteps = window length in load
+    # levels (e.g. 24 = daily), pHydDemQuota = contracted delivered volume per window
+    # [kgH2]. Both default to 0 when the columns are absent, so eHydDemandQuota Skips and
+    # existing cases are unchanged. The quota is a hydrogen quantity, so it scales by
+    # factor1 like vHydDemand (mirroring pVarMaxDemand); the step count is a unit-less
+    # window length and is not scaled.
+    for _q_col, _q_def in (('pHydDemQuotaSteps', 0), ('pHydDemQuota', 0.0)):
+        if _q_col in parameters_dict:
+            parameters_dict[_q_col] = parameters_dict[_q_col].fillna(_q_def)
+        else:
+            parameters_dict[_q_col] = pd.Series(_q_def, index=parameters_dict['pHydDemFlexible'].index)
+    parameters_dict['pHydDemQuotaSteps'] = parameters_dict['pHydDemQuotaSteps'].astype(int)
+    parameters_dict['pHydDemQuota'] = parameters_dict['pHydDemQuota'] * factor1
+
     # Per-step buy/sell caps (MaxBuy/MaxSell) are optional retail columns. When a
     # retail file omits them, default the cap to 0.0, read as "no cap" by the
     # eRetMaxBuy/Sell constraints (they skip a zero cap). The hydrogen retail file

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -541,6 +541,24 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
     optmodel.__setattr__('eEleDemandShiftBalance', Constraint(optmodel.psned, rule=eEleDemandShiftBalance, doc='Electricity demand shift balance'))
 
+    # Hydrogen delivered-volume quota. Over each window of pHydDemQuotaSteps load levels
+    # the SCHEDULED hydrogen (vHydDemand, duration-weighted) must meet the contracted
+    # volume pHydDemQuota; hours within the window are free up to the per-hour cap
+    # (vHydDemand upper bound), so production can shift to cheap hours and buffer in
+    # storage. Physical shortfall stays soft through the per-hour vHNS penalty. Skips
+    # (no-op) unless pHydDemQuotaSteps is set, so existing cases are unchanged. This is the
+    # hydrogen analogue of the electricity demand shift above, but a volume floor rather
+    # than a shift-preserving balance.
+    def eHydDemandQuota(optmodel, p,sc,n,hd):
+        steps = model.Par['pHydDemQuotaSteps'][hd]
+        if model.Par['pHydDemFlexible'][hd] == 1.0 and steps and model.n.ord(n) % steps == 0:
+            window = n2_list[model.n.ord(n) - steps:model.n.ord(n)]
+            scheduled = sum(optmodel.vHydDemand[p,sc,n2,hd] * model.Par['pDuration'][p,sc,n2] for n2 in window)
+            return scheduled >= model.Par['pHydDemQuota'][hd]
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eHydDemandQuota', Constraint(optmodel.psnhd, rule=eHydDemandQuota, doc='Hydrogen scheduled-volume quota per window [kgH2]'))
+
     # Hydrogen not served cannot exceed the hydrogen demand actually scheduled.
     # Flexible hydrogen demand is a curtailable range [min, max] (the hydrogen demand
     # file carries no shift parameter, so there is no electricity-style recovery

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1249,3 +1249,54 @@ def test_factor1_invariant():
     c2 = _cost(2.0)
     assert abs(c2 - c1) <= 1e-5 * max(1.0, abs(c1)), \
         f"factor1 must leave the optimum invariant: cost {c1} (f1=1) vs {c2} (f1=2)"
+
+
+def test_hydrogen_demand_quota_noop_by_default(h2_model):
+    """Hydrogen demand volume quota: ``eHydDemandQuota`` is declared but Skips for every
+    index unless a demand carries ``pHydDemQuotaSteps`` > 0. Shipped cases set no quota,
+    so the constraint is empty (no-op) and the default parameters are 0 -- the guarantee
+    that this feature leaves existing solves byte-unchanged."""
+    m = h2_model
+    assert hasattr(m, "eHydDemandQuota"), "quota constraint was not declared"
+    assert len(m.eHydDemandQuota) == 0, \
+        "quota constraint must be empty (no-op) when no demand carries a quota"
+    assert len(m.hd) > 0, "test case has no hydrogen demand"
+    for hd in m.hd:
+        assert int(m.Par['pHydDemQuotaSteps'][hd]) == 0, "default quota steps must be 0"
+        assert float(m.Par['pHydDemQuota'][hd]) == 0.0, "default quota volume must be 0"
+
+
+def test_hydrogen_demand_quota_activates_when_set(tmp_path):
+    """When a hydrogen demand is Flexible and carries pHydDemQuotaSteps > 0, the
+    eHydDemandQuota constraint builds one volume floor per window, and the floor is the
+    duration-weighted sum of vHydDemand over the window. Injects a 2-step quota into a
+    copy of the H2Tank case (24 load levels -> 12 windows)."""
+    import duckdb
+
+    src_db = os.path.join(SIZING_DIR, "H2Tank.duckdb")
+    if not os.path.isfile(src_db):
+        subprocess.run([sys.executable, os.path.join(SIZING_DIR, "make_sizing_cases.py")],
+                       check=True, cwd=REPO)
+    work = str(tmp_path)
+    db = os.path.join(work, "H2TankQuota.duckdb")
+    shutil.copy(src_db, db)
+    con = duckdb.connect(db)
+    con.execute("ALTER TABLE data_HydrogenDemand ADD COLUMN QuotaSteps INTEGER")
+    con.execute("ALTER TABLE data_HydrogenDemand ADD COLUMN Quota DOUBLE")
+    con.execute("UPDATE data_HydrogenDemand SET Flexible='Yes', QuotaSteps=2, Quota=1.0")
+    con.close()
+
+    date = datetime.datetime.now().replace(second=0, microsecond=0)
+    m = build_model(work, "H2TankQuota", date)
+
+    assert any(int(m.Par['pHydDemQuotaSteps'][hd]) == 2 for hd in m.hd), \
+        "quota steps did not load from the demand table"
+    assert len(m.eHydDemandQuota) == len(m.n) // 2 * len(m.hd), \
+        "expected one quota constraint per 2-step window per demand"
+    # each row is the window sum of vHydDemand >= the (factor1-scaled) quota
+    idx = next(iter(m.eHydDemandQuota))
+    repn = generate_standard_repn(m.eHydDemandQuota[idx].body)
+    assert len(repn.linear_vars) == 2 and all(c == pytest.approx(1.0) for c in repn.linear_coefs), \
+        "window floor must be the unit-weighted sum of two vHydDemand terms"
+    assert all(v.name.startswith("vHydDemand") for v in repn.linear_vars), \
+        "quota floor must be on the scheduled demand vHydDemand"


### PR DESCRIPTION
  Hydrogen demand was a per-hour band with no cumulative-volume obligation, so
  elastic demand behaved like merchant arbitrage. This adds an optional period
  quota: over each window of pHydDemQuotaSteps load levels the scheduled hydrogen
  must meet a contracted volume pHydDemQuota, with the hours free up to the per-hour
  cap. Mirrors the electricity demand-shift mechanism.

  Off by default: both params default to 0 when the demand columns are absent, so
  the constraint Skips and existing cases/goldens are byte-unchanged. The quota
  volume scales by factor1 like the demand.

  Tests: no-op default (empty constraint on a shipped case) and activation (a 2-step
  quota on H2Tank builds one window floor per window with the right expression).