### PR TITLE
Add physical FCR constraints for the fuel cell (h2e)

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -463,6 +463,14 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
             parameters_dict[end_col] = parameters_dict[end_col].fillna(0.0)
         else:
             parameters_dict[end_col] = pd.Series(0.0, index=parameters_dict['pHydGenProductionFunction'].index)
+    # Electricity-generator (incl. fuel-cell h2e) FCR endurance windows in minutes. When
+    # the electricity-generation data omits these columns the endurance defaults to 0, so
+    # the new fuel-cell up-endurance constraints have a zero left-hand side and stay inert.
+    for end_col in ['pEleGenEnduranceFCRD', 'pEleGenEnduranceFCRN']:
+        if end_col in parameters_dict:
+            parameters_dict[end_col] = parameters_dict[end_col].fillna(0.0)
+        else:
+            parameters_dict[end_col] = pd.Series(0.0, index=parameters_dict['pEleGenProductionFunction'].index)
     parameters_dict['pEleGenRES'               ] = parameters_dict['pEleGenRES'               ].map(idxDict)
     parameters_dict['pEleGenESS'               ] = parameters_dict['pEleGenESS'               ].map(idxDict)
     parameters_dict['pEleGenEV'                ] = parameters_dict['pEleGenEV'                ].map(idxDict)

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -119,17 +119,17 @@ def create_objective_function_components(model, optmodel, indlog):
         # pay a non-RES unit that is neither thermal nor storage -- it has a bid variable
         # but no cap, no provision and is never fixed, so its bid would be free and the
         # paid revenue would make the objective unbounded (C17).
-        return optmodel.vTotalEleFCRDUpRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egt]) for egt in model.egt) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs]) for egs in model.egs) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h]) for e2h in model.e2h)
+        return optmodel.vTotalEleFCRDUpRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egt]) for egt in model.egt) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs]) for egs in model.egs) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h]) for e2h in model.e2h) + sum((model.Par['pOperatingReservePrice_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,h2e]) for h2e in model.h2e if model.Par['pEleGenNoFCRD'][h2e] == 0)
     optmodel.__setattr__('eEleMarketFCRDUpRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRDUpRevenue, doc='Total electricity market FCR-D upwards revenues [kEUR]'))
 
     def eEleMarketFCRDDwRevenue(optmodel, p,sc,n):
         # backed providers only (egt / egs / e2h), as in eEleMarketFCRDUpRevenue (C17)
-        return optmodel.vTotalEleFCRDDwRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egt]) for egt in model.egt) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs]) for egs in model.egs) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]) for e2h in model.e2h)
+        return optmodel.vTotalEleFCRDDwRev[p,sc,n] == sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egt]) for egt in model.egt) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs]) for egs in model.egs) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]) for e2h in model.e2h) + sum((model.Par['pOperatingReservePrice_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,h2e]) for h2e in model.h2e if model.Par['pEleGenNoFCRD'][h2e] == 0)
     optmodel.__setattr__('eEleMarketFCRDDwRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRDDwRevenue, doc='Total electricity market FCR-D downwards revenues [kEUR]'))
 
     def eEleMarketFCRNRevenue(optmodel, p,sc,n):
         # backed providers only (egt / egs / e2h), as in eEleMarketFCRDUpRevenue (C17)
-        return optmodel.vTotalEleFCRNRev[p,sc,n] == sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egt]) for egt in model.egt) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs]) for egs in model.egs) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h]) for e2h in model.e2h)
+        return optmodel.vTotalEleFCRNRev[p,sc,n] == sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egt]) for egt in model.egt) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs]) for egs in model.egs) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h]) for e2h in model.e2h) + sum(((model.Par['pOperatingReservePrice_FCRN_Up'][p,sc,n] + model.Par['pOperatingReservePrice_FCRN_Down'][p,sc,n]) / 2 * optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e]) for h2e in model.h2e if model.Par['pEleGenNoFCRN'][h2e] == 0)
     optmodel.__setattr__('eEleMarketFCRNRevenue', Constraint(optmodel.psn, rule=eEleMarketFCRNRevenue, doc='Total electricity market FCR-N revenues [kEUR]'))
 
     #%% Total hydrogen market costs
@@ -621,21 +621,21 @@ def create_constraints(model, optmodel, indlog):
     # FCR-D required
     def eEleFreqContReserveDisUpward(optmodel, p,sc,n):
         if sum(1 for egt in model.egt if model.Par['pEleGenNoFCRD'][egt] == 0) + sum(1 for egs in model.egs if model.Par['pEleGenNoFCRD'][egs] == 0) + sum(1 for e2h in model.e2h if model.Par['pHydGenNoFCRD'][e2h] == 0):
-            return sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRD'][egt] == 0) + sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRD'][egs] == 0) + sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRD'][e2h] == 0) <= model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n]
+            return sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRD'][egt] == 0) + sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRD'][egs] == 0) + sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRD'][e2h] == 0) + sum(optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,h2e] for h2e in model.h2e if model.Par['pEleGenNoFCRD'][h2e] == 0) <= model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqContReserveDisUpward', Constraint(optmodel.psn, rule=eEleFreqContReserveDisUpward, doc='Frequency containment reserve - upward'))
 
     def eEleFreqContReserveDisDownward(optmodel, p,sc,n):
         if sum(1 for egt in model.egt if model.Par['pEleGenNoFCRD'][egt] == 0) + sum(1 for egs in model.egs if model.Par['pEleGenNoFCRD'][egs] == 0) + sum(1 for e2h in model.e2h if model.Par['pHydGenNoFCRD'][e2h] == 0):
-            return sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRD'][egt] == 0) + sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRD'][egs] == 0) + sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRD'][e2h] == 0) <= model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n]
+            return sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRD'][egt] == 0) + sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRD'][egs] == 0) + sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRD'][e2h] == 0) + sum(optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,h2e] for h2e in model.h2e if model.Par['pEleGenNoFCRD'][h2e] == 0) <= model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqContReserveDisDownward', Constraint(optmodel.psn, rule=eEleFreqContReserveDisDownward, doc='Frequency containment reserve - downward'))
 
     def eEleFreqContReserveNor(optmodel, p,sc,n):
         if sum(1 for egt in model.egt if model.Par['pEleGenNoFCRN'][egt] == 0) + sum(1 for egs in model.egs if model.Par['pEleGenNoFCRN'][egs] == 0) + sum(1 for e2h in model.e2h if model.Par['pHydGenNoFCRN'][e2h] == 0):
-            return sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRN'][egt] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRN'][egs] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRN'][e2h] == 0) <= min(model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n], model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n])
+            return sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egt] for egt in model.egt if model.Par['pEleGenNoFCRN'][egt] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,egs] for egs in model.egs if model.Par['pEleGenNoFCRN'][egs] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,e2h] for e2h in model.e2h if model.Par['pHydGenNoFCRN'][e2h] == 0) + sum(optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e] for h2e in model.h2e if model.Par['pEleGenNoFCRN'][h2e] == 0) <= min(model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n], model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n])
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleFreqContReserveNor', Constraint(optmodel.psn, rule=eEleFreqContReserveNor, doc='Frequency containment reserve - normal'))
@@ -966,6 +966,97 @@ def create_constraints(model, optmodel, indlog):
                   - optmodel.vHydTotalCharge[p,sc,n,hgs] for hgs in comp_at_node)
         return lhs <= rhs
     optmodel.__setattr__('eEleFreqDownCompressorRate', Constraint(optmodel.psnnd, rule=eEleFreqDownCompressorRate, doc='Electrolyser FCR-down extra production rate bounded by spare node compressor throughput'))
+
+    # --- Fuel cell (h2e) FCR provision: generation-side mirror of the thermal-generator
+    # formulation. A fuel cell is a hydrogen-fired generator (h2e is a subset of model.eg),
+    # so it offers FCR by modulating its electricity output (FCR-up = produce more, FCR-down
+    # = back off). The bids are the same variables the thermal generators use, already summed
+    # into the FCR requirement and revenue. These constraints give them the missing physical
+    # backing. Gated on the generator's own participation flags pEleGenNoFCRD / pEleGenNoFCRN
+    # (default 1), so a unit only offers FCR when those columns are set to "No". The FCR-N
+    # bid (NorBid) is symmetric: it appears in both the up-headroom (1) and the down-headroom
+    # (2), so it is automatically bounded by min(spare-up, output) -- the correct two-sided
+    # availability for a generator.
+    #
+    # 1. Up-bid headroom: the up bid (FCR-D up + FCR-N) cannot exceed the spare generation
+    #    capacity, i.e. built MaxPower minus the current output. For a candidate fuel cell the
+    #    capacity is the built fraction (MaxPower * build); for a fixed unit it is MaxPower
+    #    directly (mirrors the candidate/fixed split used for the storage and electrolyser
+    #    headroom constraints).
+    def eEleFreqUpHeadroomFuelCell(optmodel, p,sc,n,h2e):
+        if (model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRD'][h2e] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][h2e] == 0):
+            if h2e in model.egc:
+                return optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,h2e] + optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e] <= model.Par['pEleMaxPower'][h2e][p,sc,n] * optmodel.vEleGenInvest[h2e] - optmodel.vEleTotalOutput[p,sc,n,h2e]
+            return optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,h2e] + optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e] <= model.Par['pEleMaxPower'][h2e][p,sc,n] - optmodel.vEleTotalOutput[p,sc,n,h2e]
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleFreqUpHeadroomFuelCell', Constraint(optmodel.psnh2e, rule=eEleFreqUpHeadroomFuelCell, doc='FCR-D and FCR-N upward headroom for a fuel cell (spare generation capacity)'))
+
+    # 2. Down-bid headroom: the down bid (FCR-D down + FCR-N) cannot exceed the current
+    #    output, because a generator can back off only as far as zero.
+    def eEleFreqDownHeadroomFuelCell(optmodel, p,sc,n,h2e):
+        if (model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRD'][h2e] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][h2e] == 0):
+            return optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,h2e] + optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e] <= optmodel.vEleTotalOutput[p,sc,n,h2e]
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleFreqDownHeadroomFuelCell', Constraint(optmodel.psnh2e, rule=eEleFreqDownHeadroomFuelCell, doc='FCR-D and FCR-N downward headroom for a fuel cell (can back down to zero)'))
+
+    # 3. Availability bound: the up and down bids, scaled by the nameplate, cannot exceed the
+    #    unit's fixed availability (mirrors eEleFreqUpDischargeBound / eEleFreqDownDischargeBound
+    #    for storage and eEleFreqUpChargeBoundConv for the electrolyser).
+    def eEleFreqUpBoundFuelCell(optmodel, p,sc,n,h2e):
+        if ((model.Par['pOperatingReserveRequire_FCRD_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRD'][h2e] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Up'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][h2e] == 0)) and model.Par['pEleMaxPower'][h2e][p,sc,n]:
+            return (optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,h2e] + optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e]) / model.Par['pEleMaxPower'][h2e][p,sc,n] <= model.Par['pVarFixedAvailability'][h2e][p,sc,n]
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleFreqUpBoundFuelCell', Constraint(optmodel.psnh2e, rule=eEleFreqUpBoundFuelCell, doc='FCR upward availability bound for a fuel cell'))
+
+    def eEleFreqDownBoundFuelCell(optmodel, p,sc,n,h2e):
+        if ((model.Par['pOperatingReserveRequire_FCRD_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRD'][h2e] == 0) or (model.Par['pOperatingReserveRequire_FCRN_Down'][p,sc,n] > 0 and model.Par['pEleGenNoFCRN'][h2e] == 0)) and model.Par['pEleMaxPower'][h2e][p,sc,n]:
+            return (optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,h2e] + optmodel.vEleFreqContReserveNorBid[p,sc,n,h2e]) / model.Par['pEleMaxPower'][h2e][p,sc,n] <= model.Par['pVarFixedAvailability'][h2e][p,sc,n]
+        else:
+            return Constraint.Skip
+    optmodel.__setattr__('eEleFreqDownBoundFuelCell', Constraint(optmodel.psnh2e, rule=eEleFreqDownBoundFuelCell, doc='FCR downward availability bound for a fuel cell'))
+
+    # 4. NOVEL upward endurance, node level. This is the dual of the electrolyser down-endurance
+    #    (eEleFreqDownEnduranceConv): a fuel cell sustaining an UP bid over the endurance window
+    #    BURNS hydrogen, so the hydrogen it would consume must already be available in the node's
+    #    tanks. lhs = sum over h2e at the node of the energy that would be delivered over the
+    #    endurance window (EnduranceFCRD/60 * up-bid + EnduranceFCRN/60 * Nor-bid), converted to
+    #    kg of hydrogen by dividing by the production function (electricity per kg). rhs = the
+    #    hydrogen actually stored in the node's tanks (tank CONTENTS, not headroom). The bid at
+    #    n-1 is backed by the inventory at n, mirroring the rolling form of the electrolyser
+    #    constraint; the first level is skipped. With EnduranceFCRD/N defaulting to 0 the
+    #    left-hand side is 0, so the constraint is inert for cases that do not set an endurance.
+    def eEleFreqUpEnduranceFuelCell(optmodel, p,sc,n,nd):
+        if n == model.n.first():
+            return Constraint.Skip
+        h2e_at_node = [h2e for h2e in model.h2e if (nd,h2e) in model.n2eg and (model.Par['pEleGenNoFCRD'][h2e] == 0 or model.Par['pEleGenNoFCRN'][h2e] == 0)]
+        hgs_at_node = [hgs for hgs in model.hgs if (nd,hgs) in model.n2hg]
+        if not h2e_at_node:
+            return Constraint.Skip
+        lhs = sum(((model.Par['pEleGenEnduranceFCRD'][h2e]/60) * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,model.n.prev(n,1),h2e]
+                 + (model.Par['pEleGenEnduranceFCRN'][h2e]/60) * optmodel.vEleFreqContReserveNorBid       [p,sc,model.n.prev(n,1),h2e]) / model.Par['pEleGenProductionFunction'][h2e] for h2e in h2e_at_node)
+        rhs = sum(optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
+        return lhs <= rhs
+    optmodel.__setattr__('eEleFreqUpEnduranceFuelCell', Constraint(optmodel.psnnd, rule=eEleFreqUpEnduranceFuelCell, doc='Fuel-cell FCR-up endurance bounded by node hydrogen-store contents'))
+
+    # C30: the rolling endurance above backs the bid at n-1 with the store contents at n and
+    # skips the first level, leaving the last level's bid unbacked. Add a terminal row that
+    # backs the last level's bid with the last level's store contents (mirrors
+    # eEleFreqDownEnduranceConvEnd for the fuel-cell node).
+    def eEleFreqUpEnduranceFuelCellEnd(optmodel, p,sc,n,nd):
+        if n != model.n.last():
+            return Constraint.Skip
+        h2e_at_node = [h2e for h2e in model.h2e if (nd,h2e) in model.n2eg and (model.Par['pEleGenNoFCRD'][h2e] == 0 or model.Par['pEleGenNoFCRN'][h2e] == 0)]
+        hgs_at_node = [hgs for hgs in model.hgs if (nd,hgs) in model.n2hg]
+        if not h2e_at_node:
+            return Constraint.Skip
+        lhs = sum(((model.Par['pEleGenEnduranceFCRD'][h2e]/60) * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,h2e]
+                 + (model.Par['pEleGenEnduranceFCRN'][h2e]/60) * optmodel.vEleFreqContReserveNorBid       [p,sc,n,h2e]) / model.Par['pEleGenProductionFunction'][h2e] for h2e in h2e_at_node)
+        rhs = sum(optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
+        return lhs <= rhs
+    optmodel.__setattr__('eEleFreqUpEnduranceFuelCellEnd', Constraint(optmodel.psnnd, rule=eEleFreqUpEnduranceFuelCellEnd, doc='Fuel-cell FCR-up endurance for the terminal load level (C30)'))
 
     # print if the constraints object len is greater than 0
     if (len(optmodel.eEleFreqContReserveDisUpward) > 0 or len(optmodel.eEleFreqContReserveDisDownward) > 0 or
@@ -1524,6 +1615,13 @@ def create_constraints(model, optmodel, indlog):
 
     # Total output of a committed unit (all except the VRES units) [GW]
     def eEleTotalOutput(optmodel, p,sc,n,egnr):
+        # A fuel cell (h2e) is a hydrogen-fired generator: its output is set by the
+        # hydrogen-to-electricity relation eAllEnergy2Ele (output == hydrogen charge *
+        # production function), not by the thermal output/2nd-block blocks. It also has no
+        # vEleFreqContReserveDisUpGen reserve variable (those live on psnegt only), so skip
+        # it here -- its FCR is handled by the dedicated fuel-cell headroom/endurance rules.
+        if egnr in model.h2e:
+            return Constraint.Skip
         if model.Par['pEleMaxPower'][egnr][p,sc,n]:
             if  egnr in model.egs:
                 return optmodel.vEleTotalOutput[p,sc,n,egnr]                                           ==                                             optmodel.vEleTotalOutput2ndBlock[p,sc,n,egnr] + model.Par['pOperatingReserveActivation_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egnr] - model.Par['pOperatingReserveActivation_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownDis[p,sc,n,egnr] + model.Par['pOperatingReserveActivation_FCRN_Up'][p,sc,n] * optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egnr] - model.Par['pOperatingReserveActivation_FCRN_Down'][p,sc,n] * optmodel.vEleFreqContReserveNorDownDis[p,sc,n,egnr]

--- a/tests/test_formulation_fixes.py
+++ b/tests/test_formulation_fixes.py
@@ -1305,3 +1305,186 @@ def test_hydrogen_demand_shift_activates_when_set(tmp_path):
     repn = generate_standard_repn(m.eHydDemandShiftBalance[idx].body)
     assert len(repn.linear_vars) == 8 and all(v.name.startswith("vHydDemand") for v in repn.linear_vars), \
         "balance must sum the window's vHydDemand terms"
+
+
+# --- Fuel cell (h2e) FCR provision -------------------------------------------
+# A hydrogen fuel cell (model.h2e, a subset of the electricity generators) can be
+# sized and is already in the FCR requirement and revenue sums, but it had no
+# physical reserve-provision constraints, so it could bid unlimited FCR. The new
+# constraints give the fuel-cell bids their physical backing:
+#   eEleFreqUpHeadroomFuelCell    -- up bid  <= spare capacity (MaxPower*build - output)
+#   eEleFreqDownHeadroomFuelCell  -- down bid <= output (can back down to zero)
+#   eEleFreqUpBoundFuelCell       -- up bid / MaxPower <= availability
+#   eEleFreqDownBoundFuelCell     -- down bid / MaxPower <= availability
+#   eEleFreqUpEnduranceFuelCell   -- NOVEL: hydrogen burned over the up endurance
+#                                    window must already be in the node's tanks
+#   eEleFreqUpEnduranceFuelCellEnd-- terminal-level version of the endurance bound
+
+def test_fuel_cell_fcr_constraints_present_in_source():
+    """Source-level check: the six fuel-cell FCR rules exist, iterate over the h2e (psnh2e)
+    or node (psnnd) index, gate on the generator's own pEleGenNoFCRD / pEleGenNoFCRN flags,
+    and the novel up-endurance backs the up bid with the node's hydrogen-store CONTENTS
+    (vHydInventory), not the empty headroom the electrolyser down-endurance uses."""
+    text = open(MODEL_FORMULATION, encoding="utf-8").read()
+    for rule, idx in [
+        ("eEleFreqUpHeadroomFuelCell", "psnh2e"),
+        ("eEleFreqDownHeadroomFuelCell", "psnh2e"),
+        ("eEleFreqUpBoundFuelCell", "psnh2e"),
+        ("eEleFreqDownBoundFuelCell", "psnh2e"),
+        ("eEleFreqUpEnduranceFuelCell", "psnnd"),
+        ("eEleFreqUpEnduranceFuelCellEnd", "psnnd"),
+    ]:
+        assert f"def {rule}(" in text, f"missing fuel-cell FCR rule {rule}"
+        decl = text.index(f"rule={rule},")
+        assert f"optmodel.{idx}" in text[text.index(f"def {rule}("):decl], \
+            f"{rule} must be declared over {idx}"
+
+    # up-headroom: built MaxPower minus the current output, build-fraction for a candidate
+    start = text.index("def eEleFreqUpHeadroomFuelCell(")
+    body = text[start:text.index("rule=eEleFreqUpHeadroomFuelCell,")]
+    assert "pEleMaxPower'][h2e][p,sc,n] * optmodel.vEleGenInvest[h2e] - optmodel.vEleTotalOutput[p,sc,n,h2e]" in body, \
+        "candidate fuel-cell up headroom must be MaxPower*build - output"
+    assert "pEleMaxPower'][h2e][p,sc,n] - optmodel.vEleTotalOutput[p,sc,n,h2e]" in body, \
+        "fixed fuel-cell up headroom must be MaxPower - output"
+    assert "pEleGenNoFCRD'][h2e] == 0" in body and "pEleGenNoFCRN'][h2e] == 0" in body, \
+        "up headroom must gate on the fuel cell's own opt-out flags"
+
+    # down-headroom: bounded by the output (can back down to zero)
+    start = text.index("def eEleFreqDownHeadroomFuelCell(")
+    body = text[start:text.index("rule=eEleFreqDownHeadroomFuelCell,")]
+    assert "<= optmodel.vEleTotalOutput[p,sc,n,h2e]" in body, \
+        "fuel-cell down headroom must be bounded by the output"
+
+    # novel up-endurance: lhs uses the production function and the EnduranceFCRD/N windows;
+    # rhs is the tank CONTENTS (vHydInventory), not the empty headroom
+    start = text.index("def eEleFreqUpEnduranceFuelCell(")
+    body = text[start:text.index("rule=eEleFreqUpEnduranceFuelCell,")]
+    assert "pEleGenEnduranceFCRD'][h2e]/60" in body and "pEleGenEnduranceFCRN'][h2e]/60" in body, \
+        "up endurance must weight the bids by EnduranceFCRD/N over 60 min"
+    assert "pEleGenProductionFunction'][h2e]" in body, \
+        "up endurance must convert delivered energy to kg H2 via the production function"
+    assert "rhs = sum(optmodel.vHydInventory[p,sc,n,hgs]" in body, \
+        "up endurance rhs must be the tank contents (vHydInventory), not the headroom"
+    assert "model.n2eg" in body, "up endurance must map fuel cells to nodes via n2eg"
+
+
+def test_ele_endurance_param_defaults_to_zero():
+    """The fuel-cell endurance windows pEleGenEnduranceFCRD / pEleGenEnduranceFCRN must be
+    read with a 0 default (mirroring the electrolyser pHydGenEndurance* read), so a case that
+    omits the columns has a zero-lhs up-endurance constraint and the feature stays inert."""
+    text = open(INPUT_DATA, encoding="utf-8").read()
+    assert "['pEleGenEnduranceFCRD', 'pEleGenEnduranceFCRN']" in text, \
+        "the Ele endurance default block must list both endurance params"
+    block = text[text.index("['pEleGenEnduranceFCRD', 'pEleGenEnduranceFCRN']"):]
+    block = block[:block.index("pEleGenRES")] if "pEleGenRES" in block else block[:400]
+    assert "fillna(0.0)" in block and "pd.Series(0.0" in block, \
+        "missing Ele endurance columns must default to a 0 Series"
+
+
+def _make_fuel_cell_case(work, *, endurance=2.0, n_levels=6):
+    """Copy the ElectrolyserFCR sizing case and add one fuel cell (h2e) on Node2, the node
+    that already carries the hydrogen store (PEMEL_01, MaximumStorage 22, InitialStorage 0).
+    The fuel cell has pEleGenNoFCRD/N == 0 (it offers FCR) and a positive EnduranceFCRD, so
+    the new up-endurance constraint is backed by the near-empty store. Duration is truncated
+    to ``n_levels`` load levels to keep the solve small. Returns the case name."""
+    import duckdb
+
+    src_db = os.path.join(SIZING_DIR, "ElectrolyserFCR.duckdb")
+    if not os.path.isfile(src_db):
+        subprocess.run([sys.executable, os.path.join(SIZING_DIR, "make_sizing_cases.py")],
+                       check=True, cwd=REPO)
+    case = "FuelCellFCR"
+    db = os.path.join(work, f"{case}.duckdb")
+    shutil.copy(src_db, db)
+    os.makedirs(os.path.join(work, case), exist_ok=True)  # results folder
+    unit = "FuelCell_01"
+    con = duckdb.connect(db)
+    # 1. register the unit in the electricity-generation dimension dict
+    con.execute(f"INSERT INTO dict_ElectricityGeneration VALUES ('{unit}')")
+    # 2. a generation row: a fixed (non-candidate) fuel cell on Node2 that converts
+    #    hydrogen to electricity (ProductionFunction = kWh per kgH2) and offers FCR.
+    egcols = [c for c in con.execute("select * from data_ElectricityGeneration limit 0").df().columns]
+    vals = {c: None for c in egcols}
+    vals.update({
+        egcols[0]: unit, "Node": "Node2", "Retailer": "EleR_01",
+        "Technology": "FuelCell", "NoDayAhead": "No", "NoFCRD": "No", "NoFCRN": "No",
+        "InitialPeriod": 2020, "FinalPeriod": 2050,
+        "MaximumPower": 5.0, "MinimumPower": 0.0,
+        "ProductionFunction": 20.0, "Availability": 1.0,
+        "EnduranceFCRD": endurance, "EnduranceFCRN": endurance,
+        "FixedAvailability": "Yes",
+    })
+    placeholders = ", ".join("?" for _ in egcols)
+    con.execute(f"INSERT INTO data_ElectricityGeneration VALUES ({placeholders})",
+                [vals[c] for c in egcols])
+    # 3. add the unit's column to every per-generator time-series table. Only fixed
+    #    availability needs a value (1 = always available); the others are left NULL so the
+    #    capacity falls back to the nameplate (the same pattern the EV / BESS units use; a
+    #    finite VarMaxGeneration would feed the GenMaximumPower fallback at the build site).
+    for tab in [r[0] for r in con.execute("show tables").fetchall()]:
+        if not tab.startswith("data_Var"):
+            continue
+        cols = con.execute(f"select * from {tab} limit 0").df().columns.tolist()
+        if "EV_01" not in cols:
+            continue
+        con.execute(f'ALTER TABLE {tab} ADD COLUMN "{unit}" DOUBLE')
+        if tab == "data_VarFixedAvailability":
+            con.execute(f'UPDATE {tab} SET "{unit}" = 1.0')
+    # 4. truncate the horizon for a fast solve: blank the Duration of later load levels so
+    #    they drop out of model.n (the same trick test_run uses), rather than deleting rows.
+    keep = [f"t{str(i + 1).zfill(4)}" for i in range(n_levels)]
+    keep_sql = ", ".join(f"'{k}'" for k in keep)
+    con.execute(f"UPDATE data_Duration SET Duration = NULL WHERE __idx2 NOT IN ({keep_sql})")
+    con.close()
+    return case, unit
+
+
+@pytest.mark.solve
+def test_fuel_cell_fcr_builds_and_binds(tmp_path):
+    """End-to-end: a fuel cell with pEleGenNoFCRD/N == 0 and EnduranceFCRD > 0 builds and
+    solves, the new fuel-cell FCR constraints have active rows, and they bind the bids:
+    the up bid never exceeds the spare capacity, the down bid never exceeds the output, and
+    the up bid is limited by the (near-empty) hydrogen store through the endurance window."""
+    work = str(tmp_path)
+    case, unit = _make_fuel_cell_case(work, endurance=2.0)
+    model = routine(dir=work, case=case, solver="highs",
+                    date=datetime.datetime.now().replace(second=0, microsecond=0),
+                    rawresults="False", plots="False", indlog="False", duckdbresults="False")
+    assert model is not None, "fuel-cell case failed to solve"
+    assert unit in set(model.h2e), "the fuel cell did not enter the h2e set"
+
+    # the new constraints were actually built (non-empty)
+    for cname in ["eEleFreqUpHeadroomFuelCell", "eEleFreqDownHeadroomFuelCell",
+                  "eEleFreqUpBoundFuelCell", "eEleFreqDownBoundFuelCell",
+                  "eEleFreqUpEnduranceFuelCell", "eEleFreqUpEnduranceFuelCellEnd"]:
+        assert len(getattr(model, cname)) > 0, f"{cname} has no active rows"
+
+    p, sc = list(model.ps)[0]
+    nd = "Node2"
+    # 1. up headroom: bid <= MaxPower - output (fixed unit, so MaxPower directly)
+    maxp = model.Par['pEleMaxPower'][unit]
+    for n in model.n:
+        up = model.vEleFreqContReserveDisUpwardBid[p, sc, n, unit]()
+        nor = model.vEleFreqContReserveNorBid[p, sc, n, unit]()
+        out = model.vEleTotalOutput[p, sc, n, unit]()
+        assert (up + nor) <= maxp[p, sc, n] - out + 1e-4, \
+            f"up bid exceeds spare capacity at {n}"
+        # 2. down headroom: down bid <= output
+        dn = model.vEleFreqContReserveDisDownwardBid[p, sc, n, unit]()
+        assert (dn + nor) <= out + 1e-4, f"down bid exceeds output at {n}"
+
+    # 3. up endurance: the hydrogen burned to hold the up bid over the endurance window
+    #    must fit in the node's store at the matching level. With InitialStorage 0 the
+    #    store starts near empty, so the endurance physically limits the first up bids.
+    end_d = model.Par['pEleGenEnduranceFCRD'][unit]
+    end_n = model.Par['pEleGenEnduranceFCRN'][unit]
+    pf = model.Par['pEleGenProductionFunction'][unit]
+    hgs_node = [hgs for hgs in model.hgs if (nd, hgs) in model.n2hg]
+    levels = list(model.n)
+    for i in range(1, len(levels)):
+        n, nprev = levels[i], levels[i - 1]
+        burned = ((end_d / 60) * model.vEleFreqContReserveDisUpwardBid[p, sc, nprev, unit]()
+                  + (end_n / 60) * model.vEleFreqContReserveNorBid[p, sc, nprev, unit]()) / pf
+        stored = sum(model.vHydInventory[p, sc, n, hgs]() for hgs in hgs_node)
+        assert burned <= stored + 1e-4, \
+            f"up endurance violated at {n}: burns {burned} kgH2 but only {stored} stored"


### PR DESCRIPTION
  The fuel cell could be sized into the FCR requirement and revenue but had no physical headroom or endurance limits, so it over-valued reserve. This adds six constraints, including an upward-endurance limit (the dual of the electrolyser tank-headroom limit), so fuel-cell FCR bids are backed by stored hydrogen.