### PR TITLE
Explicit FCR activation settlement + two deliverability fixes

### DIFF
--- a/src/el1xr_opt/Modules/oM_Decomposition.py
+++ b/src/el1xr_opt/Modules/oM_Decomposition.py
@@ -85,7 +85,8 @@ def first_stage_components() -> dict:
         "complicating": ["vEleGenInvest", "vHydGenInvest", "vTotalICost"],
         "linking": ["vEleInventory", "vHydInventory",
                     "vEleFreqContReserveDisUpwardBid", "vEleFreqContReserveDisDownwardBid",
-                    "vEleFreqContReserveNorBid"],
+                    "vEleFreqContReserveNorBid",
+                    "vHydGenCommitment", "vHydGenStandBy"],
     }
 
 
@@ -222,7 +223,10 @@ def benders_solve(make_master, make_subproblem, blocks, config=None,
     sub_tol = float(cfg.extra.get("sub_primal_tol", 1e-8))
     _name = str(solver).lower()
     if "gurobi" in _name:
-        opt_sub.options.update({"FeasibilityTol": sub_tol})
+        # Aggregate=0 stops Gurobi substituting the equality-fixed linking vars (investment /
+        # boundary copies) out of the model, which would drop their fixing-constraint duals --
+        # the LP-cut coefficients. Keeps the rest of presolve.
+        opt_sub.options.update({"FeasibilityTol": sub_tol, "Aggregate": 0})
     elif "highs" in _name:
         opt_sub.options.update({"primal_feasibility_tolerance": sub_tol})
 
@@ -236,7 +240,11 @@ def benders_solve(make_master, make_subproblem, blocks, config=None,
             sub = subs[b]
             sub["set_xhat"](x_hat)
             _solve_model(opt_sub, sub["model"])
-            lam = {n: float(sub["model"].dual[sub["fix"][n]]) for n in names}
+            # default a missing dual to 0: some solvers (gurobi) presolve a fixing constraint
+            # away when its var is also bounded, so its dual is not reported -- a zero
+            # coefficient is correct there (the constraint is not binding for that block).
+            _dmap = sub["model"].dual
+            lam = {n: float(_dmap.get(sub["fix"][n], 0.0)) for n in names}
             qb = sub["recourse"]() if "recourse" in sub else float(value(sub["obj"]))
             solved[b] = (qb, lam)
         return solved
@@ -514,11 +522,10 @@ def benders_solve(make_master, make_subproblem, blocks, config=None,
         # which the blocks cannot meet exactly (an elastic-penalty UB); the hook instead
         # recovers a feasible UB by a forward pass (boundaries free, fed block to block).
         if ub_recourse is not None:
-            recourse = ub_recourse(x_hat, subs, opt_sub)
+            ub = ub_recourse(x_hat, subs, opt_sub)   # returns the full UB (first stage + recourse)
         else:
             recourse = sum((v[2] if len(v) > 2 else v[0]) for v in solved.values())
-
-        ub = first_stage_cost + recourse
+            ub = first_stage_cost + recourse
         best_ub = min(best_ub, ub)
         gap = abs(best_ub - lb) / (abs(best_ub) + 1e-12)
         if cfg.extra.get("verbose"):
@@ -873,6 +880,50 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
         return float(cfg.extra.get("bid_cap", 1e6))
     bidcap = {u: _bid_cap(u) for (u, _bt) in bid_comp}
 
+    # --- Augmented boundary state: trailing electrolyser commitment / standby ---------
+    # The electrolyser 3-state machine (off / standby / on) couples consecutive steps: the
+    # cold-start, standby-transition and warm-continuity rows read the commitment + standby
+    # state at n-1, falling back to the pre-horizon initial UC at the first step. So when a
+    # seam falls between n-1 and n the receiving block uses the INITIAL UC instead of the
+    # previous block's realised state -- it resets the stack at every seam, mis-counting
+    # cold starts and breaking the 3-state facet across the seam. Carry the trailing
+    # commitment + standby across the seam (binary linking state, tight under the Lagrangian
+    # with no extra binarisation) so the receiving block reads the true previous state.
+    # Inert (no new state) for a case with no electrolyser commitment.
+    carry_commit = bool(cfg.extra.get("carry_commitment", True))
+
+    def _e2h_commit_active(u):
+        sb = su = 0
+        try:
+            sb = int(full.Par['pHydGenStandByStatus'][u])
+        except (KeyError, TypeError):
+            pass
+        try:
+            su = float(full.Par['pHydGenStartUpCost'][u])
+        except (KeyError, TypeError):
+            pass
+        return (sb == 1) or (su > 0.0)
+
+    commit_comp = []                                 # list of (e2h unit, 'commit'|'standby')
+    if carry_commit:
+        for u in e2h_units:
+            if _e2h_commit_active(u):
+                commit_comp += [(u, 'commit'), (u, 'standby')]
+    commit_names = [("Commit", k, u, st) for k in range(K - 1) for (u, st) in commit_comp]
+    _COMMITVAR = {'commit': 'vHydGenCommitment', 'standby': 'vHydGenStandBy'}
+
+    def _e2h_sb(u):
+        try:
+            return int(full.Par['pHydGenStandByStatus'][u]) == 1
+        except (KeyError, TypeError):
+            return False
+
+    def _e2h_su(u):
+        try:
+            return float(full.Par['pHydGenStartUpCost'][u]) > 0.0
+        except (KeyError, TypeError):
+            return False
+
     def _binary(kind, g):
         key = 'pEleGenBinaryInvestment' if kind == "e" else 'pHydGenBinaryInvestment'
         try:
@@ -910,6 +961,12 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
                     bounds=lambda mm, k, u, bt: (0.0, bidcap[u]), initialize=0.0)
         for (_tag, k, u, bt) in bid_names:
             x[("Bid", k, u, bt)] = m.Bid[k, u, bt]
+        # trailing electrolyser commitment / standby (binary: a finite linking state, so the
+        # Lagrangian cut is tight on it without any extra binarisation). No master cost.
+        m.Commit = Var([(k, u, st) for k in range(max(K - 1, 1)) for (u, st) in commit_comp],
+                       within=Binary, initialize=0)
+        for (_tag, k, u, st) in commit_names:
+            x[("Commit", k, u, st)] = m.Commit[k, u, st]
         if _binstate:
             # binary-expand each boundary state onto a [0, cap] grid (cap = nameplate*factor1),
             # so the dualised subproblem copies are bounded (Lagrangian bounded) and the cuts
@@ -1003,9 +1060,10 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
         sub._st = Param(range(max(K - 1, 1)), hts, mutable=True, initialize=0.0)
         # The boundary copies are bounded to [0, cap] when the state is binarised, so the
         # dualised Lagrangian (cut_mode='lagrangian') is bounded; otherwise free (LP mode).
-        _seb = (lambda mm, k, g: (0.0, maxE[g] * factor1)) if _binstate else None
-        _shb = (lambda mm, k, g: (0.0, maxH[g] * factor1)) if _binstate else None
-        _stb = (lambda mm, k, s: (0.0, maxHt[s] * factor1)) if _binstate else None
+        _bnd_copies = _binstate or bool(cfg.extra.get("bound_lp_copies", False))
+        _seb = (lambda mm, k, g: (0.0, maxE[g] * factor1)) if _bnd_copies else None
+        _shb = (lambda mm, k, g: (0.0, maxH[g] * factor1)) if _bnd_copies else None
+        _stb = (lambda mm, k, s: (0.0, maxHt[s] * factor1)) if _bnd_copies else None
         sub.Secopy = Var(range(max(K - 1, 1)), egs, within=Reals, bounds=_seb)
         sub.Shcopy = Var(range(max(K - 1, 1)), hgs, within=Reals, bounds=_shb)
         sub.Stcopy = Var(range(max(K - 1, 1)), hts, within=Reals, bounds=_stb)
@@ -1027,6 +1085,18 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
             sub.Bidcopy = Var(_bidx, within=Reals, bounds=_bidb)
             sub.bidfix = Constraint(
                 _bidx, rule=lambda mm, kk, u, bt: mm.Bidcopy[kk, u, bt] == mm._bid[kk, u, bt])
+
+        # trailing electrolyser commitment / standby copies (one per seam, e2h unit, state).
+        # Tied to the master Commit value (commitfix, the cut's dual source); the incoming
+        # (k-1) one feeds the receiving block's 3-state rows, the outgoing (k) one is tied to
+        # this window's last-level state. Bounded to [0, 1] (binary state) so the dualised
+        # copy is bounded.
+        _cmx = [(kk, u, st) for kk in range(max(K - 1, 1)) for (u, st) in commit_comp]
+        if commit_comp:
+            sub._commit = Param(_cmx, mutable=True, initialize=0.0)
+            sub.Commitcopy = Var(_cmx, within=Reals, bounds=(0.0, 1.0))
+            sub.commitfix = Constraint(
+                _cmx, rule=lambda mm, kk, u, st: mm.Commitcopy[kk, u, st] == mm._commit[kk, u, st])
 
         # incoming boundary (k > 0): replace the window's first-level inventory
         # balance (which uses the constant initial inventory) with one reading the
@@ -1157,6 +1227,41 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
                           for hs in hgs_node[nd] if (p, sc, a, hs) in sub.vHydInventory)
                 sub.seam_endur.add(lhs <= rhs)
 
+        # --- straddling electrolyser 3-state: sending and receiving sides of each seam.
+        commit_set = set(commit_comp)
+        if commit_comp and k < K - 1:
+            # sending side: tie this window's last-level (b) commitment/standby to the copy.
+            def _out_commit(mm, u, st):
+                cv = getattr(mm, _COMMITVAR[st])
+                if (p, sc, b, u) not in cv:
+                    return Constraint.Skip
+                return cv[p, sc, b, u] == mm.Commitcopy[k, u, st]
+            sub.out_commit = Constraint(list(commit_comp), rule=_out_commit)
+        if commit_comp and k > 0:
+            # receiving side: the window's first-level 3-state rows used the pre-horizon
+            # initial UC; replace them with rows reading the previous block's carried state.
+            def _cc(u, st):
+                return sub.Commitcopy[k - 1, u, st] if (u, st) in commit_set else 0.0
+            sub.seam_commit = ConstraintList()
+            for u in e2h_units:
+                if (u, 'commit') not in commit_set or (p, sc, a, u) not in sub.vHydGenCommitment:
+                    continue
+                for cn in ("eHydElectrolyserStandByTransition", "eHydElectrolyserColdStart",
+                           "eHydElectrolyserWarmContinuity"):
+                    c = getattr(sub, cn, None)
+                    if c is not None and (p, sc, a, u) in c:
+                        c[p, sc, a, u].deactivate()
+                if _e2h_sb(u):                          # standby only reachable when warm at t-1
+                    sub.seam_commit.add(sub.vHydGenStandBy[p, sc, a, u]
+                                        <= _cc(u, 'commit') + _cc(u, 'standby'))
+                if _e2h_su(u):                          # cold start = off(t-1)->on(t)
+                    sub.seam_commit.add(sub.vHydGenStartUp[p, sc, a, u]
+                                        >= sub.vHydGenCommitment[p, sc, a, u]
+                                        - _cc(u, 'commit') - _cc(u, 'standby'))
+                if _e2h_sb(u) and getattr(sub, "eHydElectrolyserWarmContinuity", None) is not None:
+                    sub.seam_commit.add(sub.vHydGenCommitment[p, sc, a, u] + sub.vHydGenStandBy[p, sc, a, u]
+                                        <= _cc(u, 'commit') + _cc(u, 'standby') + sub.vHydGenStartUp[p, sc, a, u])
+
         sub.eTotalSCost.deactivate()
 
         # threshold-LP: drop this window's own peak charge(s) and inject the window's
@@ -1216,7 +1321,7 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
         # fixing and the u-definition are exact too, so they stay hard.
         keep_hard = ("bfix_e", "bfix_h", "sefix", "shfix", "stfix",
                      "rep_e", "rep_h", "rep_ht", "out_e", "out_h", "out_ht",
-                     "tpkfix", "upkdef", "bidfix", "out_bid")
+                     "tpkfix", "upkdef", "bidfix", "out_bid", "commitfix", "out_commit")
         targets = [c for c in sub.component_objects(Constraint, active=True)
                    if c.name not in keep_hard]
         TransformationFactory('core.add_slack_variables').apply_to(sub, targets=targets)
@@ -1264,6 +1369,8 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
             fix[("t",) + key] = sub.tpkfix[key]
         for (_tag, kk, u, bt) in bid_names:
             fix[("Bid", kk, u, bt)] = sub.bidfix[kk, u, bt]
+        for (_tag, kk, u, st) in commit_names:
+            fix[("Commit", kk, u, st)] = sub.commitfix[kk, u, st]
 
         def set_xhat(x_hat):
             for g in egc:
@@ -1277,6 +1384,8 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
                 sub._tpk[key] = x_hat[("t",) + key]
             for (_tag, kk, u, bt) in bid_names:
                 sub._bid[kk, u, bt] = x_hat[("Bid", kk, u, bt)]
+            for (_tag, kk, u, st) in commit_names:
+                sub._commit[kk, u, st] = x_hat[("Commit", kk, u, st)]
 
         xcopy = {("e", g): sub.vEleGenInvest[g] for g in egc}
         xcopy.update({("h", g): sub.vHydGenInvest[g] for g in hgc})
@@ -1291,6 +1400,9 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
         if bid_comp:
             for (_tag, kk, u, bt) in bid_names:
                 xcopy[("Bid", kk, u, bt)] = sub.Bidcopy[kk, u, bt]
+        if commit_comp:
+            for (_tag, kk, u, st) in commit_names:
+                xcopy[("Commit", kk, u, st)] = sub.Commitcopy[kk, u, st]
         # keys this block actually couples on (for the Lagrangian cut_mode): all investment,
         # its own incoming (k-1) / outgoing (k) boundaries, and the thresholds its window hits.
         active_keys = ([("e", g) for g in egc] + [("h", g) for g in hgc]
@@ -1299,90 +1411,135 @@ def el1xr_temporal_benders(dir_name, case_name, date, n_time_blocks=2,
             active_keys += [("t", ti, sub_maps[ti][nn], it) for (ti, it, nn) in thr_u]
         if bid_comp:
             active_keys += [("Bid", kk, u, bt) for (_tag, kk, u, bt) in bid_names if kk in (k - 1, k)]
+        if commit_comp:
+            active_keys += [("Commit", kk, u, st) for (_tag, kk, u, st) in commit_names if kk in (k - 1, k)]
         return {"model": sub, "xcopy": xcopy, "fix": fix, "set_xhat": set_xhat,
                 "obj": sub.benders_obj, "recourse": recourse_value, "active_keys": active_keys}
 
+    # investment build-fraction upper bounds, for the built-up incumbent below
+    _inv_up = {}
+    for g in egc:
+        try:
+            _inv_up[("e", g)] = float(full.Par['pEleGenInvestmentUp'][g])
+        except (KeyError, TypeError):
+            _inv_up[("e", g)] = 1.0
+    for g in hgc:
+        try:
+            _inv_up[("h", g)] = float(full.Par['pHydGenInvestmentUp'][g])
+        except (KeyError, TypeError):
+            _inv_up[("h", g)] = 1.0
+
     def _forward_ub(x_hat, subs, opt_sub):
-        # SDDiP forward pass for a clean upper bound. Fix the investment (and the peak
-        # thresholds) to the master point and solve the blocks in time order: each block's
-        # INCOMING boundary is fixed to the previous block's realised OUTGOING state and its
-        # own outgoing boundary is left FREE, so the block chooses its end inventory. The
-        # boundary states are then feasible by construction (no grid-mismatch elastic
-        # penalty), so the summed real recourse is a true upper bound -- unlike fixing every
-        # boundary to the binarised-grid master value, which the blocks cannot meet exactly.
-        # For the reserve-endurance coupling there is one extra step: each sending block's
-        # terminal endurance rows are re-activated for this primal sweep (see below), so it
-        # retains the energy needed to back its trailing bid in the next block.
+        # SDDiP forward pass for a clean upper bound: solve the blocks in time order with the
+        # investment fixed and the boundary fed block to block (incoming fixed to the previous
+        # outgoing, own outgoing FREE), so the boundary states are feasible by construction and
+        # the summed real recourse is a true UB. Returns the FULL cost (first stage + recourse).
+        # Two incumbents are evaluated and the cheaper kept: (A) the master's investment, which
+        # may be fractional/under-built mid-convergence -> a loose UB; and (B) a BUILT-UP
+        # incumbent that bumps every candidate the master is investing in to its upper bound, so
+        # the operating problem is feasible -> a valid (possibly over-built) UB that does not
+        # blow up on slack. For the reserve-endurance coupling each sending block's terminal
+        # endurance rows are re-activated for this primal sweep so it retains the energy needed
+        # to back its trailing bid in the next block.
         from pyomo.environ import value as _val
-        prevE, prevH, prevHt = dict(initE), dict(initH), dict(initHt)
-        prevBid = {(u, bt): 0.0 for (u, bt) in bid_comp}   # carried trailing bids
-        total = 0.0
-        for k in range(K):
-            s = subs[k]; m = s["model"]
-            s["set_xhat"](x_hat)
-            # switch the block out of its Lagrangian state into a primal forward solve.
-            if hasattr(m, "_lag_obj"):
-                m._lag_obj.deactivate()
-            s["obj"].activate()
-            for g in egc:
-                m.bfix_e[g].activate()
-            for g in hgc:
-                m.bfix_h[g].activate()
-            for key in thr_keys:
-                m.tpkfix[key].activate()
-            if k > 0:                              # incoming boundary = previous outgoing
-                for g in egs:
-                    m._se[k - 1, g] = prevE[g]; m.sefix[k - 1, g].activate()
-                for g in hgs:
-                    m._sh[k - 1, g] = prevH[g]; m.shfix[k - 1, g].activate()
-                for sn in hts:
-                    m._st[k - 1, sn] = prevHt[sn]; m.stfix[k - 1, sn].activate()
-                for (u, bt) in bid_comp:           # incoming trailing bid = previous outgoing
-                    m._bid[k - 1, u, bt] = prevBid[(u, bt)]; m.bidfix[k - 1, u, bt].activate()
-            # re-activate this (sending) block's terminal endurance rows for the primal
-            # heuristic only: they back the trailing bid with the block's own ending
-            # inventory, so the greedy sweep retains enough energy and the next block can
-            # back the bid -- otherwise the exact split (which moves that backing to the
-            # next block) leaves this block free to end empty and the UB blows up on slack.
-            for cn in getattr(m, "_fwd_end_rows", []):
-                getattr(m, cn).activate()
-            # this block's outgoing boundary (index k) stays unfixed: the block picks it.
-            _solve_model(opt_sub, m)
-            # forward-pass UB: ignore per-constraint slack below a small tolerance, so a
-            # binarisation grid-mismatch residual is not amplified by the 1e7 penalty.
-            total += s["recourse"](slack_tol=float(cfg.extra.get("fwd_slack_tol", 1e-4)))
-            if k < K - 1:                          # read the realised outgoing state
-                for g in egs:
-                    prevE[g] = float(_val(m.Secopy[k, g]))
-                for g in hgs:
-                    prevH[g] = float(_val(m.Shcopy[k, g]))
-                for sn in hts:
-                    prevHt[sn] = float(_val(m.Stcopy[k, sn]))
-                for (u, bt) in bid_comp:
-                    prevBid[(u, bt)] = float(_val(m.Bidcopy[k, u, bt]))
-            # restore the Lagrangian state (active-key fixings off, _lag_obj on) for the
-            # next cut-generation pass.
-            for cn in getattr(m, "_fwd_end_rows", []):
-                getattr(m, cn).deactivate()   # back to the exact-split state
-            s["obj"].deactivate()
-            if hasattr(m, "_lag_obj"):
-                m._lag_obj.activate()
-            for g in egc:
-                m.bfix_e[g].deactivate()
-            for g in hgc:
-                m.bfix_h[g].deactivate()
-            for key in thr_keys:
-                m.tpkfix[key].deactivate()
-            if k > 0:
-                for g in egs:
-                    m.sefix[k - 1, g].deactivate()
-                for g in hgs:
-                    m.shfix[k - 1, g].deactivate()
-                for sn in hts:
-                    m.stfix[k - 1, sn].deactivate()
-                for (u, bt) in bid_comp:
-                    m.bidfix[k - 1, u, bt].deactivate()
-        return total
+
+        def _first_stage(invest):
+            inv = period_weight * sum(invcost[nm] * invest[nm] for nm in inv_names)
+            peak = (discount * sum(thresholds[ti]["coeff_of"][it] * thresholds[ti]["count"]
+                                   * x_hat[("t", ti, sg, it)] for (ti, sg, it) in thr_keys)
+                    if thresholds else 0.0)
+            return inv + discount * const_value + peak
+
+        def _sweep(invest):
+            xh = dict(x_hat); xh.update(invest)
+            prevE, prevH, prevHt = dict(initE), dict(initH), dict(initHt)
+            prevBid = {(u, bt): 0.0 for (u, bt) in bid_comp}   # carried trailing bids
+            prevCommit = {(u, st): 0.0 for (u, st) in commit_comp}   # carried 3-state
+            total = 0.0
+            for k in range(K):
+                s = subs[k]; m = s["model"]
+                s["set_xhat"](xh)
+                # switch the block out of its Lagrangian state into a primal forward solve.
+                if hasattr(m, "_lag_obj"):
+                    m._lag_obj.deactivate()
+                s["obj"].activate()
+                for g in egc:
+                    m.bfix_e[g].activate()
+                for g in hgc:
+                    m.bfix_h[g].activate()
+                for key in thr_keys:
+                    m.tpkfix[key].activate()
+                if k > 0:                              # incoming boundary = previous outgoing
+                    for g in egs:
+                        m._se[k - 1, g] = prevE[g]; m.sefix[k - 1, g].activate()
+                    for g in hgs:
+                        m._sh[k - 1, g] = prevH[g]; m.shfix[k - 1, g].activate()
+                    for sn in hts:
+                        m._st[k - 1, sn] = prevHt[sn]; m.stfix[k - 1, sn].activate()
+                    for (u, bt) in bid_comp:           # incoming trailing bid = previous outgoing
+                        m._bid[k - 1, u, bt] = prevBid[(u, bt)]; m.bidfix[k - 1, u, bt].activate()
+                    for (u, st) in commit_comp:        # incoming 3-state = previous outgoing
+                        m._commit[k - 1, u, st] = prevCommit[(u, st)]; m.commitfix[k - 1, u, st].activate()
+                # re-activate this (sending) block's terminal endurance rows for the primal
+                # heuristic only: they back the trailing bid with the block's own ending
+                # inventory, so the greedy sweep retains enough energy and the next block can
+                # back the bid -- otherwise the exact split (which moves that backing to the
+                # next block) leaves this block free to end empty and the UB blows up on slack.
+                for cn in getattr(m, "_fwd_end_rows", []):
+                    getattr(m, cn).activate()
+                # this block's outgoing boundary (index k) stays unfixed: the block picks it.
+                _solve_model(opt_sub, m)
+                # forward-pass UB: ignore per-constraint slack below a small tolerance, so a
+                # binarisation grid-mismatch residual is not amplified by the 1e7 penalty.
+                total += s["recourse"](slack_tol=float(cfg.extra.get("fwd_slack_tol", 1e-4)))
+                if k < K - 1:                          # read the realised outgoing state
+                    for g in egs:
+                        prevE[g] = float(_val(m.Secopy[k, g]))
+                    for g in hgs:
+                        prevH[g] = float(_val(m.Shcopy[k, g]))
+                    for sn in hts:
+                        prevHt[sn] = float(_val(m.Stcopy[k, sn]))
+                    for (u, bt) in bid_comp:
+                        prevBid[(u, bt)] = float(_val(m.Bidcopy[k, u, bt]))
+                    for (u, st) in commit_comp:
+                        prevCommit[(u, st)] = float(_val(m.Commitcopy[k, u, st]))
+                # restore the Lagrangian state (active-key fixings off, _lag_obj on) for the
+                # next cut-generation pass.
+                for cn in getattr(m, "_fwd_end_rows", []):
+                    getattr(m, cn).deactivate()   # back to the exact-split state
+                s["obj"].deactivate()
+                if hasattr(m, "_lag_obj"):
+                    m._lag_obj.activate()
+                for g in egc:
+                    m.bfix_e[g].deactivate()
+                for g in hgc:
+                    m.bfix_h[g].deactivate()
+                for key in thr_keys:
+                    m.tpkfix[key].deactivate()
+                if k > 0:
+                    for g in egs:
+                        m.sefix[k - 1, g].deactivate()
+                    for g in hgs:
+                        m.shfix[k - 1, g].deactivate()
+                    for sn in hts:
+                        m.stfix[k - 1, sn].deactivate()
+                    for (u, bt) in bid_comp:
+                        m.bidfix[k - 1, u, bt].deactivate()
+                    for (u, st) in commit_comp:
+                        m.commitfix[k - 1, u, st].deactivate()
+            return total
+
+        # (A) the master's investment
+        x_inv = {nm: x_hat[nm] for nm in inv_names}
+        ub = _first_stage(x_inv) + _sweep(x_inv)
+        # (B) built-up incumbent: bump every candidate the master is investing in (> 1e-3) to
+        # its upper bound; leave the unwanted ones at their (near-zero) master value. Only run
+        # the extra sweep when it actually differs from (A).
+        if bool(cfg.extra.get("fwd_buildup", True)):
+            x_up = {nm: (_inv_up.get(nm, 1.0) if x_inv[nm] > 1e-3 else x_inv[nm]) for nm in inv_names}
+            if any(x_up[nm] > x_inv[nm] + 1e-6 for nm in inv_names):
+                ub = min(ub, _first_stage(x_up) + _sweep(x_up))
+        return ub
 
     return benders_solve(make_master, make_subproblem, blocks, config=cfg, solver=solver,
                          cut_mode=cut_mode,

--- a/src/el1xr_opt/Modules/oM_GreenHydrogen.py
+++ b/src/el1xr_opt/Modules/oM_GreenHydrogen.py
@@ -81,8 +81,13 @@ def create_green_hydrogen(model, optmodel, indlog):
             # quantity (x factor1), so the price carries 1/factor1 -- like the day-ahead energy
             # price (pVarEnergyCost, scaled at read) -- to keep price x quantity invariant under
             # the unit scale. At factor1=1 this is unchanged (goldens byte-unchanged).
+            # Take-as-produced means must-take: the buyer pays the strike on the AVAILABLE
+            # energy (the pEleMaxPower profile), not on the dispatched output -- otherwise
+            # curtailing the contracted wind is a free option and the PPA is undervalued.
+            # Dispatch remains free to curtail physically; PPA units are existing
+            # (non-candidate) plants, so no invest-scaling applies.
             return optmodel.vTotalEleMrkPPACost[p, sc, n] == sum(
-                model.Par['pEleGenPPAPrice'][egppa] / model.factor1 * optmodel.vEleTotalOutput[p, sc, n, egppa] for egppa in ppa_units)
+                model.Par['pEleGenPPAPrice'][egppa] / model.factor1 * model.Par['pEleMaxPower'][egppa][(p, sc, n)] for egppa in ppa_units)
         optmodel.__setattr__('eEleMarketPPACost', Constraint(model.psn, rule=eEleMarketPPACost, doc='electricity PPA take-as-produced cost'))
         # REVIEW (virtual PPA): vTotalEleMrkPPARev stays at zero (physical PPA).
         # For a virtual PPA contract-for-difference, free and define it here too.

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -125,6 +125,48 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
     # generation-cost block below and the realistic electrolyser values in the data.
     model.factor1 = factor1
 
+    # Money base (per-case, from the Parameter 'MoneyBase' column; default 1.0 = no scaling). This is
+    # the single in-model money-conditioning knob: every money-valued INPUT is divided by money_base
+    # here, so the case-builder can write raw currency and the model owns the scaling. It rides on top
+    # of factor1 (which converts per-quantity prices for the extensive basis); together they set the
+    # money coefficient magnitudes. Optimum-invariant (a uniform scale on the objective); the reported
+    # objective is scaled back for display. Column list mirrors build_case._scale_money (+ ByproductCredit).
+    money_base = 1.0
+    if 'MoneyBase' in data_frames['dfParameter'].columns:
+        _mb = data_frames['dfParameter']['MoneyBase'].iloc[0]
+        if _mb == _mb and float(_mb) > 0:
+            money_base = float(_mb)
+    model.money_base = money_base
+    if money_base != 1.0:
+        _money_cols = {
+            'Parameter': ['ENSCost', 'HNSCost', 'CO2Cost', 'EleConnInvestCost'],
+            'ElectricityGeneration': ['FuelCost', 'OMVariableCost', 'LinearTerm', 'ConstantTerm',
+                'StartUpCost', 'ShutDownCost', 'FixedInvestmentCost', 'FixedRetirementCost',
+                'PPAPrice', 'DegradationCost', 'DoDS1', 'DoDS2', 'DoDS3'],
+            'HydrogenGeneration': ['FuelCost', 'OMVariableCost', 'LinearTerm', 'ConstantTerm',
+                'StartUpCost', 'ShutDownCost', 'FixedInvestmentCost', 'FixedRetirementCost',
+                'DegradationCost', 'CompressorInvestCost', 'DegradationCost2ndBlock',
+                'RampDegradationCost', 'ByproductCredit'],
+            'ElectricityRetail': ['Fastavgift', 'Overforingsavgift', 'PowerTariff', 'EnergyTax',
+                'Paslag', 'HighLoadTariff', 'OverforingHigh'],
+            'HydrogenRetail': ['paslag', 'netavgift'],
+            'HydrogenDemand': ['Price'],
+        }
+        _money_allcols = ['VarEnergyPrice', 'VarEnergyCost', 'OperatingReservePrice']
+        for _stem, _cols in _money_cols.items():
+            _df = data_frames.get(f'df{_stem}')
+            if _df is not None:
+                for _c in _cols:
+                    if _c in _df.columns:
+                        _df[_c] = pd.to_numeric(_df[_c], errors='coerce') / money_base
+        for _stem in _money_allcols:
+            _df = data_frames.get(f'df{_stem}')
+            if _df is not None:
+                for _c in _df.columns:
+                    _s = pd.to_numeric(_df[_c], errors='coerce')
+                    if _s.notna().mean() > 0.5:   # value column (money); skip any string index columns
+                        _df[_c] = _s / money_base
+
     # Option Indicators
     option_ind = data_frames['dfOption'].columns.to_list()
 
@@ -325,6 +367,10 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         # term misses; default zero so existing cases are unaffected.
         if f'p{sector[0:3]}GenRampDegradationCost' not in parameters_dict:
             parameters_dict[f'p{sector[0:3]}GenRampDegradationCost'] = pd.Series(0.0, index=data_frames[_df_gen_key].index)
+        # Byproduct (O2 + waste heat) valorisation credit per kgH2 of output; a per-quantity
+        # CREDIT applied as a negative term in eTotalHydGCost (default 0 -> existing cases unchanged).
+        if f'p{sector[0:3]}GenByproductCredit' not in parameters_dict:
+            parameters_dict[f'p{sector[0:3]}GenByproductCredit'] = pd.Series(0.0, index=data_frames[_df_gen_key].index)
         # factor1 (audit C38): per-quantity PRICES carry 1/factor1 so price x quantity (which
         # scales by factor1) is invariant. LinearVarCost, CO2EmissionCost and OMVariableCost are
         # such prices; the CO2 emission RATE is a dimensionless ratio and is no longer factored.
@@ -342,6 +388,8 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         parameters_dict[f'p{sector[0:3]}GenDegradationCost2ndBlock'] = parameters_dict[f'p{sector[0:3]}GenDegradationCost2ndBlock'] / model.factor1
         # M2b: cycling degradation, a per-quantity price on |delta consumption| -> 1/factor1 (default 0).
         parameters_dict[f'p{sector[0:3]}GenRampDegradationCost'] = parameters_dict[f'p{sector[0:3]}GenRampDegradationCost'] / model.factor1
+        # Byproduct credit (per kgH2) is a per-quantity price, so it carries 1/factor1 (default 0).
+        parameters_dict[f'p{sector[0:3]}GenByproductCredit'] = parameters_dict[f'p{sector[0:3]}GenByproductCredit'] / model.factor1
         parameters_dict[f'p{sector[0:3]}GenInvestCost'        ] = parameters_dict[f'p{sector[0:3]}GenFixedInvestmentCost' ]        * parameters_dict[f'p{sector[0:3]}GenFixedChargeRate']                                                                          # generation fixed cost                   [MEUR]
         parameters_dict[f'p{sector[0:3]}GenRetireCost'        ] = parameters_dict[f'p{sector[0:3]}GenFixedRetirementCost' ]        * parameters_dict[f'p{sector[0:3]}GenFixedChargeRate']                                                                          # generation fixed retirement cost        [MEUR]                                                                           # H2 outflows ramp down rate              [tonH2]
 
@@ -1231,6 +1279,12 @@ def create_variables(model, optmodel, indlog):
     setattr(optmodel, 'vTotalEleMrkDARev',                 Var(model.psn,     within=             Reals, doc='total electricity day-ahead market revenue                           [EUR]'))
     setattr(optmodel, 'vTotalEleMrkPPARev',                Var(model.psn,     within=             Reals, doc='total electricity PPA market       revenue                           [EUR]'))
     setattr(optmodel, 'vTotalEleMrkFrqRev',                Var(model.psn,     within=             Reals, doc='total electricity frequency market revenue                           [EUR]'))
+    # reserve activation-energy settlement (pOptIndReserveDeliverySettlement): delivered
+    # upward energy earns, absorbed downward energy pays, at the day-ahead price (the
+    # conservative proxy for the regulation price). Kept as separate named components so a
+    # real up/down regulation-price series can replace the proxy without touching constraints.
+    setattr(optmodel, 'vTotalEleActRev',                   Var(model.psn,     within=             Reals, doc='reserve activation energy settlement revenue (upward, at DA price)   [EUR]'))
+    setattr(optmodel, 'vTotalEleActCost',                  Var(model.psn,     within=             Reals, doc='reserve activation energy settlement cost   (downward, at DA price)  [EUR]'))
 
     # ancillary services revenues
     setattr(optmodel, 'vTotalEleFCRDUpRev',                Var(model.psn,     within=             Reals, doc='total electricity FCR-D up    market revenue                         [EUR]'))
@@ -1286,6 +1340,13 @@ def create_variables(model, optmodel, indlog):
                 optmodel.vHydGenRampAbs[_idx].fix(0.0)
     setattr(optmodel, 'vEleBuy',                           Var(model.psner,   within=NonNegativeReals, doc='electricity retail  buy                                                 [kW]'))
     setattr(optmodel, 'vEleSell',                          Var(model.psner,   within=NonNegativeReals, doc='electricity retail  sell                                                [kW]'))
+    # Reserve delivery/settlement (pOptIndReserveDeliverySettlement): baseline day-ahead
+    # POSITION, distinct from the metered exchange above. The metered exchange equals the
+    # baseline shifted by the kappa-weighted net reserve activation (delivery identity in
+    # oM_ModelFormulation), so activated energy must cross the meter and cannot be "delivered"
+    # by internal re-routing. Fixed to zero when the option is off (vars then appear nowhere).
+    setattr(optmodel, 'vEleBuyBase',                       Var(model.psner,   within=NonNegativeReals, doc='electricity baseline day-ahead buy position                             [kW]'))
+    setattr(optmodel, 'vEleSellBase',                      Var(model.psner,   within=NonNegativeReals, doc='electricity baseline day-ahead sell position                            [kW]'))
     setattr(optmodel, 'vEleDemand',                        Var(model.psned,   within=NonNegativeReals, doc='electricity demand                                                      [kW]'))
     setattr(optmodel, 'vENS',                              Var(model.psned,   within=NonNegativeReals, doc='electricity not served                                                  [kW]'))
     setattr(optmodel, 'vEleTotalOutput',                   Var(model.psneg,   within=NonNegativeReals, doc='total electricity output of the unit                                    [kW]'))
@@ -1322,7 +1383,7 @@ def create_variables(model, optmodel, indlog):
 
     setattr(optmodel, 'vEleNetFlow',                       Var(model.psnela,  within=           Reals, doc='electricity net flow                                                    [kW]'))
     setattr(optmodel, 'vHydNetFlow',                       Var(model.psnhpa,  within=           Reals, doc='hydrogen    net flow                                                  [kgH2]'))
-    setattr(optmodel, 'vEleNetTheta',                      Var(model.psnnd,   within=           Reals, doc='electricity net theta                                                   [kW]'))
+    setattr(optmodel, 'vEleNetTheta',                      Var(model.psnnd,   within=           Reals, doc='electricity net voltage angle                                          [rad]'))
 
     setattr(optmodel, 'vEleFreqContReserveDisUpwardBid',   Var(model.psnege2h, within=NonNegativeReals, doc='electricity frequency containment reserve upward bid                   [kW]'))
     setattr(optmodel, 'vEleFreqContReserveDisDownwardBid', Var(model.psnege2h, within=NonNegativeReals, doc='electricity frequency containment reserve downward bid                 [kW]'))
@@ -1458,7 +1519,8 @@ def create_variables(model, optmodel, indlog):
 
     sub_rev_vars = [optmodel.vTotalEleMrkDARev,
                     optmodel.vTotalHydMrkPPARev,
-                    optmodel.vTotalEleISRev, optmodel.vTotalEleMrkFrqRev, optmodel.vTotalEleFCRDUpRev, optmodel.vTotalEleFCRDDwRev]
+                    optmodel.vTotalEleISRev, optmodel.vTotalEleMrkFrqRev, optmodel.vTotalEleFCRDUpRev, optmodel.vTotalEleFCRDDwRev,
+                    optmodel.vTotalEleActRev, optmodel.vTotalEleActCost]
 
     # ed_vars = [optmodel.vENS]
 
@@ -1473,11 +1535,23 @@ def create_variables(model, optmodel, indlog):
         var.setub(zero_upper_bound)
 
     # Electricity
+    _delivery_on = int(model.Par.get('pOptIndReserveDeliverySettlement', 0)) == 1
     for idx in model.psner:
         optmodel.vEleBuy [idx].setlb(model.Par['pEleRetMinimumEnergyBuy' ][idx[-1]])
         optmodel.vEleBuy [idx].setub(model.Par['pEleRetMaximumEnergyBuy' ][idx[-1]])
         optmodel.vEleSell[idx].setlb(model.Par['pEleRetMinimumEnergySell'][idx[-1]])
         optmodel.vEleSell[idx].setub(model.Par['pEleRetMaximumEnergySell'][idx[-1]])
+        if _delivery_on:
+            # baseline position lives under the same commercial limits as the metered exchange
+            optmodel.vEleBuyBase [idx].setub(model.Par['pEleRetMaximumEnergyBuy' ][idx[-1]])
+            optmodel.vEleSellBase[idx].setub(model.Par['pEleRetMaximumEnergySell'][idx[-1]])
+        else:
+            optmodel.vEleBuyBase [idx].fix(0.0)
+            optmodel.vEleSellBase[idx].fix(0.0)
+    if not _delivery_on:
+        for idx in model.psn:
+            optmodel.vTotalEleActRev [idx].fix(0.0)
+            optmodel.vTotalEleActCost[idx].fix(0.0)
 
     for idx in model.psned:
         if model.Par['pEleDemFlexible'][idx[-1]] == 0.0:
@@ -2092,11 +2166,11 @@ def create_variables(model, optmodel, indlog):
     for idx in model.psnegs:
         if model.Par['pEleMaxCharge'][idx[-1]][idx[:(len(idx)-1)]] + model.Par['pEleMaxPower'][idx[-1]][idx[:(len(idx)-1)]] > 0.0:
             if model.n.ord(idx[-2]) == model.Par['pEleCycleTimeStep'][idx[-1]]:
-                if model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]] + sum(model.Par['pDuration'][idx[:(len(idx)-2)]+(n2,)] * (model.Par['pEleMaxInflows'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] - model.Par['pEleMinPower'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] + model.Par['pEleGenEfficiency'][idx[-1]] * model.Par['pEleMaxCharge'][idx[-1]][idx[:(len(idx)-2)]+(n2,)]) for n2 in list(model.n2)[model.n.ord(idx[-2]) - model.Par['pEleCycleTimeStep'][idx[-1]]:model.n.ord(idx[-2])]) < model.Par['pEleMinStorage'][idx[-1]][idx[:(len(idx)-1)]]:
+                if model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]] + sum(model.Par['pDuration'][idx[:(len(idx)-2)]+(n2,)] * (model.Par['pEleMaxInflows'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] - model.Par['pEleMinPower'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] + model.Par['pEleGenEfficiency'][idx[-1]] * model.Par['pEleMaxCharge'][idx[-1]][idx[:(len(idx)-2)]+(n2,)]) for n2 in list(model.n2)[model.n.ord(idx[-2]) - model.Par['pEleCycleTimeStep'][idx[-1]]:model.n.ord(idx[-2])]) < model.Par['pEleMinStorage'][idx[-1]][idx[:(len(idx)-1)]] * model.factor1:
                     print('### Inventory equation violation ', idx)
                     assert(0==1)
             elif model.n.ord(idx[-2]) > model.Par['pEleCycleTimeStep'][idx[-1]]:
-                if model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] + sum(model.Par['pDuration'][idx[:(len(idx)-2)]+(n2,)] * (model.Par['pEleMaxInflows'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] - model.Par['pEleMinPower'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] + model.Par['pEleGenEfficiency'][idx[-1]] * model.Par['pEleMaxCharge'][idx[-1]][idx[:(len(idx)-2)]+(n2,)]) for n2 in list(model.n2)[model.n.ord(idx[-2]) - model.Par['pEleCycleTimeStep'][idx[-1]]:model.n.ord(idx[-2])]) < model.Par['pEleMinStorage'][idx[-1]][idx[:(len(idx)-1)]]:
+                if model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] * model.factor1 + sum(model.Par['pDuration'][idx[:(len(idx)-2)]+(n2,)] * (model.Par['pEleMaxInflows'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] - model.Par['pEleMinPower'][idx[-1]][idx[:(len(idx)-2)]+(n2,)] + model.Par['pEleGenEfficiency'][idx[-1]] * model.Par['pEleMaxCharge'][idx[-1]][idx[:(len(idx)-2)]+(n2,)]) for n2 in list(model.n2)[model.n.ord(idx[-2]) - model.Par['pEleCycleTimeStep'][idx[-1]]:model.n.ord(idx[-2])]) < model.Par['pEleMinStorage'][idx[-1]][idx[:(len(idx)-1)]] * model.factor1:
                     print('### Inventory equation violation ', idx)
                     assert(0==1)
 
@@ -2109,30 +2183,37 @@ def create_variables(model, optmodel, indlog):
     #         optmodel.__getattribute__(f'vHydCommitment')[idx].fix(1.0)
     #         nFixedVariables += 2
 
-    # identify if MaxStorage is equal to MinStorage for some ESS units
+    # identify if MaxStorage is equal to MinStorage for some ESS units.
+    # factor1 fix: pEleMaxStorage/pEleMinStorage are read raw (factor1 is applied per use site), while
+    # vEleEnergyInflows/Outflows and pEleInitialInventory are factor1-scaled. Scale the storage caps by
+    # model.factor1 here so the fixed values and comparisons share one basis (was raw-vs-scaled when
+    # factor1 != 1). Only fires for fixed-inventory (MaxStorage==MinStorage) units -- none in this case.
+    f1 = model.factor1
     for idx in model.psnegs:
+        cur = idx[:(len(idx)-1)]
+        maxS = model.Par['pEleMaxStorage'][idx[-1]][cur] * f1
+        minS = model.Par['pEleMinStorage'][idx[-1]][cur] * f1
         if model.n.ord(idx[-2]) > 1:
             prev_idx = idx[:(len(idx) - 2)] + (model.n.prev(idx[-2]),)
-            if abs(model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleMinStorage'][idx[-1]][idx[:(len(idx)-1)]]) <= 1e-5 and abs(model.Par['pEleMaxStorage'][idx[-1]][prev_idx] - model.Par['pEleMinStorage'][idx[-1]][prev_idx]) <= 1e-5:
-                # compare the pEleMaxStorage of the current time step with the one of the previous time step
-                if model.Par['pEleMaxStorage'][idx[-1]][prev_idx] > model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]]:
-                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].setub(model.Par['pEleMaxStorage'][idx[-1]][prev_idx] - model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]])
-                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].fix(model.Par['pEleMaxStorage'][idx[-1]][prev_idx] - model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]])
-                elif model.Par['pEleMaxStorage'][idx[-1]][prev_idx] < model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]]:
-                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].setub(model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleMaxStorage'][idx[-1]][prev_idx])
-                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].fix(model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleMaxStorage'][idx[-1]][prev_idx])
-                # else:
-                #     optmodel.__getattribute__(f'vEleEnergyInflows')[idx].fix(0.0)
-                #     optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].fix(0.0)
-                #     nFixedVariables += 2
+            maxS_prev = model.Par['pEleMaxStorage'][idx[-1]][prev_idx] * f1
+            minS_prev = model.Par['pEleMinStorage'][idx[-1]][prev_idx] * f1
+            if abs(maxS - minS) <= 1e-5 and abs(maxS_prev - minS_prev) <= 1e-5:
+                # compare the (scaled) MaxStorage of the current time step with the previous one
+                if maxS_prev > maxS:
+                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].setub(maxS_prev - maxS)
+                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].fix(maxS_prev - maxS)
+                elif maxS_prev < maxS:
+                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].setub(maxS - maxS_prev)
+                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].fix(maxS - maxS_prev)
         else:
-            if abs(model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleMinStorage'][idx[-1]][idx[:(len(idx)-1)]]) <= 1e-5:
-                if model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]] > model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]]:
-                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].setub(model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]])
-                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].fix(model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]])
-                elif model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]] < model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]]:
-                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].setub(model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]])
-                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].fix(model.Par['pEleMaxStorage'][idx[-1]][idx[:(len(idx)-1)]] - model.Par['pEleInitialInventory'][idx[-1]][idx[:(len(idx)-1)]])
+            init = model.Par['pEleInitialInventory'][idx[-1]][cur]  # already factor1-scaled
+            if abs(maxS - minS) <= 1e-5:
+                if init > maxS:
+                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].setub(init - maxS)
+                    optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].fix(init - maxS)
+                elif init < maxS:
+                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].setub(maxS - init)
+                    optmodel.__getattribute__(f'vEleEnergyInflows')[idx].fix(maxS - init)
                 # else:
                 #     optmodel.__getattribute__(f'vEleEnergyInflows')[idx].fix(0.0)
                 #     optmodel.__getattribute__(f'vEleEnergyOutflows')[idx].fix(0.0)

--- a/src/el1xr_opt/Modules/oM_Investment.py
+++ b/src/el1xr_opt/Modules/oM_Investment.py
@@ -66,12 +66,23 @@ def _extract_for_unit(v, g, pd):
     return None
 
 
+# Computed merit-order warm-start states (not per-unit INPUT parameters): the model pre-commits
+# generators in set order until initial demand is met, so two otherwise-identical units can get
+# different initial output/UC purely by position. Excluded from the identity signature so identical
+# candidates (e.g. two identical wind plants) are still detected and ordered.
+_WARMSTART_PARAMS = frozenset({'pEleInitialOutput', 'pEleInitialUC', 'pHydInitialOutput', 'pHydInitialUC'})
+
+
 def _unit_signature(Par, g, pd):
     """A unit's signature = every per-unit parameter value it carries, in name order.
     Two units with equal signatures are interchangeable (identical in every parameter
-    the model reads), so ordering their build is valid symmetry-breaking."""
+    the model reads), so ordering their build is valid symmetry-breaking. Computed
+    warm-start states (see _WARMSTART_PARAMS) are excluded -- they are merit-order
+    artifacts, not inputs, and identical units may differ there."""
     sig = []
     for name in sorted(Par):
+        if name in _WARMSTART_PARAMS:
+            continue
         val = _extract_for_unit(Par[name], g, pd)
         if val is not None:
             sig.append((name, val))
@@ -333,6 +344,48 @@ def create_investment(model, optmodel, indlog):
         return optmodel.vHydGenShutDown[p, sc, n, g] <= optmodel.vHydGenInvest[g]
     optmodel.__setattr__('eHydInvestShutDown', Constraint(psn_hyd_uc, rule=eHydInvestShutDown, doc='candidate hydrogen unit can shut down only up to its build fraction'))
 
+    # %% Grid-connection capacity investment (industrial VPP; opt-in via pParEleConnInvestCost>0).
+    # An industrial VPP builds its own grid connection up to the point of common coupling
+    # (transformer, switchgear, cable) -- real project capex the DSO does not bear. Size ONE
+    # bidirectional connection capacity that must cover both the import (electrolyser load,
+    # battery charge) and the export (wind, battery / fuel-cell discharge) at each retail node,
+    # and pay its annualized per-kW capex. The effekttariff prices ongoing peak USE; this prices
+    # the connection CAPEX and makes the connection size an endogenous trade-off with the asset
+    # builds. Default off (parameter absent or 0), so cases without it are byte-unchanged. The
+    # cost coefficient carries 1/factor1 (a 'Cost' Parameter) and multiplies the extensive
+    # capacity, so the product is unit-invariant like the other operating-cost terms.
+    conn_cost = float(model.Par.get('pParEleConnInvestCost', 0.0) or 0.0)
+    optmodel._conn_active = conn_cost > 0.0
+    if optmodel._conn_active:
+        setattr(optmodel, 'vEleConnCap', Var(within=NonNegativeReals, doc='invested grid-connection capacity [kW, factor1-scaled like other powers]'))
+        # Grid exchange physically occurs at the electricity reference (slack) node: the model couples
+        # vEleImport/vEleExport to the retail buy/sell there and fixes them to zero at every other node.
+        # So the connection must bound import/export at the reference node (not the retailer node -- the
+        # two coincide only when the retailer sits on the reference node).
+        conn_nodes = sorted(model.endrf) or sorted({model.Par['pEleRetNode'][er] for er in model.er})
+        psn_conn = [(p, sc, n, nd) for (p, sc, n) in model.psn for nd in conn_nodes]
+
+        def eEleConnImport(optmodel, p, sc, n, nd):
+            return optmodel.vEleImport[p, sc, n, nd] <= optmodel.vEleConnCap
+        optmodel.__setattr__('eEleConnImport', Constraint(psn_conn, rule=eEleConnImport, doc='grid import bounded by the invested connection capacity'))
+
+        def eEleConnExport(optmodel, p, sc, n, nd):
+            return optmodel.vEleExport[p, sc, n, nd] <= optmodel.vEleConnCap
+        optmodel.__setattr__('eEleConnExport', Constraint(psn_conn, rule=eEleConnExport, doc='grid export bounded by the invested connection capacity'))
+
+        # Reserve delivery/settlement option: the BASELINE day-ahead position must also fit the
+        # invested connection (a position beyond deliverable capacity cannot be scheduled). This
+        # is what stops a down-activation bid from being "delivered" by scheduling a baseline
+        # export above the physical cap and absorbing own curtailed generation instead.
+        if int(model.Par.get('pOptIndReserveDeliverySettlement', 0)) == 1:
+            def eEleConnBuyBase(optmodel, p, sc, n, er):
+                return optmodel.vEleBuyBase[p, sc, n, er] <= optmodel.vEleConnCap
+            optmodel.__setattr__('eEleConnBuyBase', Constraint(model.psner, rule=eEleConnBuyBase, doc='baseline buy position bounded by the invested connection capacity'))
+
+            def eEleConnSellBase(optmodel, p, sc, n, er):
+                return optmodel.vEleSellBase[p, sc, n, er] <= optmodel.vEleConnCap
+            optmodel.__setattr__('eEleConnSellBase', Constraint(model.psner, rule=eEleConnSellBase, doc='baseline sell position bounded by the invested connection capacity'))
+
     # %% Total investment cost
     # Unit scaling: model.factor1 is the conversion factor that lets the model work
     # at either utility (MWh) or local/home (kWh) scale. It is applied to the
@@ -360,10 +413,14 @@ def create_investment(model, optmodel, indlog):
     period_weight = sum(model.Par['pDiscountFactor'][p] for p in model.p)
 
     def eTotalICost(optmodel):
+        # Grid-connection capex (annualized, per invested kW of connection capacity); 0 when the
+        # feature is off. Recurs each period like the asset capex, so it is period-weighted too.
+        conn_term = (conn_cost * optmodel.vEleConnCap) if getattr(optmodel, '_conn_active', False) else 0.0
         return optmodel.vTotalICost == period_weight * (
             sum(model.Par['pEleGenInvestCost'][egc] * optmodel.vEleGenInvest[egc] for egc in model.egc) +
             sum(model.Par['pHydGenInvestCost'][hgc] * optmodel.vHydGenInvest[hgc] for hgc in model.hgc) +
-            sum(model.Par['pHydGenCompressorInvestCost'][hgs] * optmodel.vHydCompInvest[hgs] for hgs in model.hgcompc))
+            sum(model.Par['pHydGenCompressorInvestCost'][hgs] * optmodel.vHydCompInvest[hgs] for hgs in model.hgcompc) +
+            conn_term)
     optmodel.__setattr__('eTotalICost', Constraint(rule=eTotalICost, doc='total period-weighted investment cost'))
 
     log_time('--- Declaring the investment (capacity-sizing) layer:', StartTime, ind_log=indlog)

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -6,6 +6,7 @@
 # erik.alvarez@ri.se
 
 # Importing Libraries
+import os            # env-gated model options
 import time          # count clock time
 from   pyomo.environ     import Constraint, Objective, minimize
 from   collections       import defaultdict
@@ -116,23 +117,80 @@ def create_objective_function_components(model, optmodel, indlog):
         return (optmodel.vTotalEleNetUseFixCost[p,sc] == sum(model.Par['pEleRetFastavgift'][er] * sum(1 for m in model.moy) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er))
     optmodel.__setattr__('eTotalEleNetUseFixCost', Constraint(optmodel.ps, rule=eTotalEleNetUseFixCost, doc='Total electricity capacity tariff cost [kEUR]'))
 
+    # Reserve delivery/settlement option (design note 2026-07-04): when ON, the day-ahead
+    # energy legs settle the BASELINE position (vEleBuyBase/vEleSellBase) and the activated
+    # reserve energy settles explicitly at the day-ahead price (vTotalEleActRev/Cost), tied
+    # together by the delivery identity below, which forces activation across the meter.
+    # When OFF (default) everything reduces to the original formulation.
+    _delivery_on = int(model.Par.get('pOptIndReserveDeliverySettlement', 0)) == 1
+
+    # site-level kappa-weighted activated reserve energy (upward delivered / downward absorbed);
+    # bids of units that may not provide a product are fixed to zero in oM_InputData, so
+    # unfiltered sums over the provider classes are exact.
+    def _act_up(optmodel, p,sc,n):
+        prov = list(model.egt) + list(model.egs) + list(model.e2h) + list(model.h2e)
+        return sum(model.Par['pOperatingReserveActivation_FCRD_Up'][p,sc,n] * optmodel.vEleFreqContReserveDisUpwardBid[p,sc,n,g]
+                 + model.Par['pOperatingReserveActivation_FCRN_Up'][p,sc,n] * optmodel.vEleFreqContReserveNorBid[p,sc,n,g] for g in prov)
+
+    def _act_dn(optmodel, p,sc,n):
+        prov = list(model.egt) + list(model.egs) + list(model.e2h) + list(model.h2e)
+        return sum(model.Par['pOperatingReserveActivation_FCRD_Down'][p,sc,n] * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,g]
+                 + model.Par['pOperatingReserveActivation_FCRN_Down'][p,sc,n] * optmodel.vEleFreqContReserveNorBid[p,sc,n,g] for g in prov)
+
     #%% Total electricity market costs
     def eEleMarketCost(optmodel, p,sc,n):
+        if _delivery_on:
+            return (optmodel.vTotalEleMCost[p,sc,n] == optmodel.vTotalEleMrkDACost[p,sc,n] + optmodel.vTotalEleMrkPPACost[p,sc,n] + optmodel.vTotalEleActCost[p,sc,n])
         return (optmodel.vTotalEleMCost[p,sc,n] == optmodel.vTotalEleMrkDACost[p,sc,n] + optmodel.vTotalEleMrkPPACost[p,sc,n])
     optmodel.__setattr__('eEleMarketCost', Constraint(optmodel.psn, rule=eEleMarketCost, doc='Total electricity market costs [kEUR]'))
 
     def eEleMarketDayAheadCost(optmodel, p,sc,n):
+        if _delivery_on:
+            # full retail buy price (spot + paslag) on the BASELINE buy position. Keeping the
+            # markup on the baseline (not the metered) leg makes a simultaneous baseline
+            # buy+sell (a wash position) cost the markup, so the delivery identity cannot be
+            # satisfied by free wash trades and activation must genuinely move the position.
+            return optmodel.vTotalEleMrkDACost[p,sc,n] == sum((model.Par['pVarEnergyCost'][er][p,sc,n] * model.Par['pEleRetBuyingRatio'][er] + model.Par['pEleRetPaslag'][er] / model.factor1) * optmodel.vEleBuyBase[p,sc,n,er] * (1 + model.Par['pEleRetMoms'][er]) for er in model.er)
         return optmodel.vTotalEleMrkDACost[p,sc,n] == sum((model.Par['pVarEnergyCost'] [er][p,sc,n] * model.Par['pEleRetBuyingRatio'][er] + model.Par['pEleRetPaslag'][er] / model.factor1) * (optmodel.vEleBuy[p,sc,n,er]) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er)
     optmodel.__setattr__('eEleMarketDayAheadCost', Constraint(optmodel.psn, rule=eEleMarketDayAheadCost, doc='Total electricity trade cost [kEUR]'))
 
     #%% Total electricity market revenues
     def eEleMarketRevenue(optmodel, p,sc,n):
+        if _delivery_on:
+            return (optmodel.vTotalEleMRev[p,sc,n] == optmodel.vTotalEleMrkDARev[p,sc,n] + optmodel.vTotalEleMrkPPARev[p,sc,n] + optmodel.vTotalEleMrkFrqRev[p,sc,n] + optmodel.vTotalEleActRev[p,sc,n])
         return (optmodel.vTotalEleMRev[p,sc,n] == optmodel.vTotalEleMrkDARev[p,sc,n] + optmodel.vTotalEleMrkPPARev[p,sc,n] + optmodel.vTotalEleMrkFrqRev[p,sc,n])
     optmodel.__setattr__('eEleMarketRevenue', Constraint(optmodel.psn, rule=eEleMarketRevenue, doc='Total electricity market revenues [kEUR]'))
 
     def eEleMarketDayAheadRevenue(optmodel, p,sc,n):
+        if _delivery_on:
+            return optmodel.vTotalEleMrkDARev[p,sc,n] == sum(model.Par['pVarEnergyPrice'][er][p,sc,n] * model.Par['pEleRetSellingRatio'][er] * (optmodel.vEleSellBase[p,sc,n,er]) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er)
         return optmodel.vTotalEleMrkDARev[p,sc,n] == sum(model.Par['pVarEnergyPrice'][er][p,sc,n] * model.Par['pEleRetSellingRatio'][er] * (optmodel.vEleSell[p,sc,n,er]) * (1 + model.Par['pEleRetMoms'][er]) for er in model.er)
     optmodel.__setattr__('eEleMarketDayAheadRevenue', Constraint(optmodel.psn, rule=eEleMarketDayAheadRevenue, doc='Total electricity market day-ahead revenues [kEUR]'))
+
+    if _delivery_on:
+        # activation-energy settlement at the day-ahead proxy (retailer-averaged price;
+        # exact for the single-retailer case, documented caveat for multi-retailer).
+        _n_er = max(len(model.er), 1)
+
+        def eEleActUpRevenue(optmodel, p,sc,n):
+            _p_sell = sum(model.Par['pVarEnergyPrice'][er][p,sc,n] * model.Par['pEleRetSellingRatio'][er] * (1 + model.Par['pEleRetMoms'][er]) for er in model.er) / _n_er
+            return optmodel.vTotalEleActRev[p,sc,n] == _p_sell * _act_up(optmodel, p,sc,n)
+        optmodel.__setattr__('eEleActUpRevenue', Constraint(optmodel.psn, rule=eEleActUpRevenue, doc='Upward reserve activation energy settled at the DA price [kEUR]'))
+
+        def eEleActDownCost(optmodel, p,sc,n):
+            _p_buy = sum(model.Par['pVarEnergyCost'][er][p,sc,n] * model.Par['pEleRetBuyingRatio'][er] * (1 + model.Par['pEleRetMoms'][er]) for er in model.er) / _n_er
+            return optmodel.vTotalEleActCost[p,sc,n] == _p_buy * _act_dn(optmodel, p,sc,n)
+        optmodel.__setattr__('eEleActDownCost', Constraint(optmodel.psn, rule=eEleActDownCost, doc='Downward reserve activation energy settled at the DA price [kEUR]'))
+
+        # Delivery identity: the metered exchange equals the baseline position shifted by the
+        # net activated reserve energy of the whole site, so a held bid's activation must
+        # cross the meter (internal re-routing, e.g. absorbing own curtailed wind, does not
+        # count as delivery). With no bids this collapses to metered == baseline.
+        def eEleActivationDelivery(optmodel, p,sc,n):
+            return sum(optmodel.vEleBuy[p,sc,n,er] - optmodel.vEleSell[p,sc,n,er] for er in model.er) == \
+                   sum(optmodel.vEleBuyBase[p,sc,n,er] - optmodel.vEleSellBase[p,sc,n,er] for er in model.er) \
+                   + _act_dn(optmodel, p,sc,n) - _act_up(optmodel, p,sc,n)
+        optmodel.__setattr__('eEleActivationDelivery', Constraint(optmodel.psn, rule=eEleActivationDelivery, doc='Metered exchange = baseline position + net activated reserve energy [kW]'))
 
     def eEleMarketFrequencyRevenue(optmodel, p,sc,n):
         return optmodel.vTotalEleMrkFrqRev[p,sc,n] == optmodel.vTotalEleFCRDUpRev[p,sc,n] + optmodel.vTotalEleFCRDDwRev[p,sc,n] + optmodel.vTotalEleFCRNRev[p,sc,n]
@@ -287,7 +345,11 @@ def create_objective_function_components(model, optmodel, indlog):
                                                    sum(model.Par['pHydGenDegradationCost2ndBlock'][e2h] * optmodel.vEleTotalCharge2ndBlock[p,sc,n,e2h] for e2h in model.e2h) +
                                                    # M2b: cycling-degradation cost on |delta productive consumption| (the FCR-modulation stress
                                                    # the throughput term misses); active only when a unit carries RampDegradationCost > 0.
-                                                   (sum(model.Par['pHydGenRampDegradationCost'][e2h] * optmodel.vHydGenRampAbs[p,sc,n,e2h] for e2h in model.e2h) if getattr(model, '_ramp_deg_active', False) and n != model.n.first() else 0))
+                                                   (sum(model.Par['pHydGenRampDegradationCost'][e2h] * optmodel.vHydGenRampAbs[p,sc,n,e2h] for e2h in model.e2h) if getattr(model, '_ramp_deg_active', False) and n != model.n.first() else 0) -
+                                                   # Byproduct valorisation CREDIT (O2 to aquaculture + waste heat to district heating, per the
+                                                   # HiWhyV valley) per kgH2 produced -- a revenue, so SUBTRACTED from the generation cost.
+                                                   # Zero by default (pHydGenByproductCredit defaults to 0), so other cases are unchanged.
+                                                   sum(model.Par['pHydGenByproductCredit'][e2h] * optmodel.vHydTotalOutput[p,sc,n,e2h] for e2h in model.e2h))
     optmodel.__setattr__('eTotalHydGCost', Constraint(optmodel.psn, rule=eTotalHydGCost, doc='Total hydrogen generation cost [kEUR]'))
 
     # M2b: linearise |delta productive consumption| for the electrolyser cycling-degradation cost.
@@ -886,7 +948,7 @@ def create_constraints(model, optmodel, indlog):
 
     def eEleStorageEnduranceDown(optmodel, p,sc,n,egs):
         if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and model.Par['pEleMaxStorage'][egs][p,sc,n] and n != model.n.first():
-            return model.Par['pEleMaxStorage'][egs][p,sc,n] * model.factor1 - optmodel.vEleInventory[p,sc,n,egs] >= model.Par['pEleGenEfficiency_charge'][egs] * ((model.Par['pEleGenEnduranceFCRD'][egs]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,model.n.prev(n,1),egs] + (model.Par['pEleGenEnduranceFCRN'][egs]/60) * optmodel.vEleFreqContReserveNorBid[p,sc,model.n.prev(n,1),egs])
+            return model.Par['pEleMaxStorage'][egs][p,sc,n] * model.factor1 * (optmodel.vEleGenInvest[egs] if egs in model.egsc else 1.0) - optmodel.vEleInventory[p,sc,n,egs] >= model.Par['pEleGenEfficiency_charge'][egs] * ((model.Par['pEleGenEnduranceFCRD'][egs]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,model.n.prev(n,1),egs] + (model.Par['pEleGenEnduranceFCRN'][egs]/60) * optmodel.vEleFreqContReserveNorBid[p,sc,model.n.prev(n,1),egs])
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleStorageEnduranceDown', Constraint(optmodel.psnegs, rule=eEleStorageEnduranceDown, doc='Storage endurance for FCR-D and FCR-N downward'))
@@ -904,7 +966,7 @@ def create_constraints(model, optmodel, indlog):
 
     def eEleStorageEnduranceDownEnd(optmodel, p,sc,n,egs):
         if (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0) and model.Par['pEleMaxStorage'][egs][p,sc,n] and n == model.n.last():
-            return model.Par['pEleMaxStorage'][egs][p,sc,n] * model.factor1 - optmodel.vEleInventory[p,sc,n,egs] >= model.Par['pEleGenEfficiency_charge'][egs] * ((model.Par['pEleGenEnduranceFCRD'][egs]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs] + (model.Par['pEleGenEnduranceFCRN'][egs]/60) * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs])
+            return model.Par['pEleMaxStorage'][egs][p,sc,n] * model.factor1 * (optmodel.vEleGenInvest[egs] if egs in model.egsc else 1.0) - optmodel.vEleInventory[p,sc,n,egs] >= model.Par['pEleGenEfficiency_charge'][egs] * ((model.Par['pEleGenEnduranceFCRD'][egs]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,egs] + (model.Par['pEleGenEnduranceFCRN'][egs]/60) * optmodel.vEleFreqContReserveNorBid[p,sc,n,egs])
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleStorageEnduranceDownEnd', Constraint(optmodel.psnegs, rule=eEleStorageEnduranceDownEnd, doc='Storage endurance for the terminal-level FCR-D/N downward bid (C30)'))
@@ -1003,7 +1065,7 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
         lhs = sum(((model.Par['pHydGenEnduranceFCRD'][e2h]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,model.n.prev(n,1),e2h]
                  + (model.Par['pHydGenEnduranceFCRN'][e2h]/60) * optmodel.vEleFreqContReserveNorBid       [p,sc,model.n.prev(n,1),e2h]) / model.Par['pHydGenProductionFunction'][e2h] for e2h in e2h_at_node)
-        rhs = sum(model.Par['pHydMaxStorage'][hgs][p,sc,n] * model.factor1 - optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
+        rhs = sum(model.Par['pHydMaxStorage'][hgs][p,sc,n] * model.factor1 * (optmodel.vHydGenInvest[hgs] if hgs in model.hgc else 1.0) - optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
         return lhs <= rhs
     optmodel.__setattr__('eEleFreqDownEnduranceConv', Constraint(optmodel.psnnd, rule=eEleFreqDownEnduranceConv, doc='Electrolyser FCR-down endurance bounded by node hydrogen-store headroom'))
 
@@ -1019,7 +1081,7 @@ def create_constraints(model, optmodel, indlog):
             return Constraint.Skip
         lhs = sum(((model.Par['pHydGenEnduranceFCRD'][e2h]/60) * optmodel.vEleFreqContReserveDisDownwardBid[p,sc,n,e2h]
                  + (model.Par['pHydGenEnduranceFCRN'][e2h]/60) * optmodel.vEleFreqContReserveNorBid       [p,sc,n,e2h]) / model.Par['pHydGenProductionFunction'][e2h] for e2h in e2h_at_node)
-        rhs = sum(model.Par['pHydMaxStorage'][hgs][p,sc,n] * model.factor1 - optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
+        rhs = sum(model.Par['pHydMaxStorage'][hgs][p,sc,n] * model.factor1 * (optmodel.vHydGenInvest[hgs] if hgs in model.hgc else 1.0) - optmodel.vHydInventory[p,sc,n,hgs] for hgs in hgs_at_node)
         return lhs <= rhs
     optmodel.__setattr__('eEleFreqDownEnduranceConvEnd', Constraint(optmodel.psnnd, rule=eEleFreqDownEnduranceConvEnd, doc='Electrolyser FCR-down endurance for the terminal load level (C30)'))
 
@@ -1581,11 +1643,14 @@ def create_constraints(model, optmodel, indlog):
     # Maximum and minimum output of the second block of an electricity ESS [p.u.]
     def eEleMaxESSOutput2ndBlock(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxPower'][egs][p,sc,n] > 1e-5:
-            # return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= 1.0
-            if model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0:
-                return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= 1.0
-            else:
-                return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= optmodel.vEleStorDischarge[p,sc,n,egs]
+            # BUGFIX (2026-07-04): the discharge-mode gate must hold whether or not the unit may
+            # bid FCR. The FCR-capable branch previously relaxed the RHS to 1.0, which removed the
+            # charge/discharge exclusivity for FCR-capable storage (simultaneous charge+discharge
+            # in the LP) and let the mere FCR *permission* change the physical dispatch. The
+            # discharge-side reserve legs (DisUpDis, NorUpDis) belong under the same gate: upward
+            # reserve carried on the discharge leg needs the unit in discharge mode; a charging
+            # unit offers upward reserve through the charge legs instead.
+            return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxPower'][egs][p,sc,n] <= optmodel.vEleStorDischarge[p,sc,n,egs]
         elif model.Par['pEleMaxPower'][egs][p,sc,n] <= 1e-5 and model.Par['pEleGenNoDayAhead'][egs] == 0 and (model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0):
             return (optmodel.vEleTotalOutput2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisUpDis[p,sc,n,egs] + optmodel.vEleFreqContReserveNorUpDis[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= 1.0
         else:
@@ -1624,11 +1689,10 @@ def create_constraints(model, optmodel, indlog):
     # Maximum and minimum charge of an ESS [p.u.]
     def eEleMaxESSCharge2ndBlock(optmodel, p,sc,n,egs):
         if model.Par['pEleMaxCharge'][egs][p,sc,n]:
-            # return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= 1.0
-            if model.Par['pEleGenNoFCRD'][egs] == 0 or model.Par['pEleGenNoFCRN'][egs] == 0:
-                return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= 1.0
-            else:
-                return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= optmodel.vEleStorCharge[p,sc,n,egs]
+            # BUGFIX (2026-07-04): mirror of eEleMaxESSOutput2ndBlock — the charge-mode gate must
+            # hold whether or not the unit may bid FCR (the FCR-capable branch previously relaxed
+            # the RHS to 1.0). Down-reserve carried on the charge leg needs charge mode.
+            return (optmodel.vEleTotalCharge2ndBlock[p,sc,n,egs] + optmodel.vEleFreqContReserveDisDownCha[p,sc,n,egs] + optmodel.vEleFreqContReserveNorDownCha[p,sc,n,egs]) / model.Par['pEleMaxCharge'][egs][p,sc,n] <= optmodel.vEleStorCharge[p,sc,n,egs]
         else:
             return Constraint.Skip
     optmodel.__setattr__('eEleMaxESSCharge2ndBlock', Constraint(optmodel.psnegs, rule=eEleMaxESSCharge2ndBlock, doc='max charge of an ESS [p.u.]'))
@@ -2335,8 +2399,15 @@ def create_constraints(model, optmodel, indlog):
         log_time('--- Declaring the peak hour selection (daily peaks - month):', StartTime, ind_log=indlog)
         StartTime = time.time() # to compute elapsed time
 
+    # Transport mode (TRANSPORT_NET=1): drop the DC Kirchhoff (voltage-angle) equation. On a RADIAL
+    # network with unbounded voltage angles it is exactly redundant -- flows are fully determined by
+    # the nodal balance -- so removing it is bit-identical while eliminating its ill-conditioned
+    # 1/(reactance*TTC) coefficients (the [1e-4, 3e4] matrix range that stalls the barrier). Only safe
+    # on radial networks; on meshed networks the angle constraint carries the loop-flow physics.
+    _transport_net = os.environ.get('TRANSPORT_NET', '0') == '1'
+
     def eKirchhoff2ndLaw(optmodel, p,sc,n,ni,nf,cc):
-        if model.Par[('pOptIndBinSingleNode')] == 0 and model.Par['pEleNetInitialPeriod'][ni,nf,cc] <= model.Par['pParEconomicBaseYear'] and model.Par['pEleNetFinalPeriod'][ni,nf,cc] >= model.Par['pParEconomicBaseYear'] and (ni,nf,cc) in model.elea:
+        if not _transport_net and model.Par[('pOptIndBinSingleNode')] == 0 and model.Par['pEleNetInitialPeriod'][ni,nf,cc] <= model.Par['pParEconomicBaseYear'] and model.Par['pEleNetFinalPeriod'][ni,nf,cc] >= model.Par['pParEconomicBaseYear'] and (ni,nf,cc) in model.elea:
             return optmodel.vEleNetFlow[p,sc,n,ni,nf,cc] / model.Par['pEleNetTTC'][ni,nf,cc] - (optmodel.vEleNetTheta[p,sc,n,ni] - optmodel.vEleNetTheta[p,sc,n,nf]) / model.Par['pEleNetReactance'][ni,nf,cc] / model.Par['pEleNetTTC'][ni,nf,cc] * 0.1 == 0
         else:
             return Constraint.Skip


### PR DESCRIPTION
  - RESERVE_DELIVERY flag: baseline market positions, delivery identity (activation energy must cross the meter), settlement at the DA price.
  - Endurance rows invest-scaled for candidate storage.
  - 2nd-block charge/discharge always mode-gated (removes the FCR-capable relaxation branch).