### PR TITLE
Make the H2VPPFCR bundle runnable on its own

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -4,6 +4,13 @@
 #                   correctness is enforced by running them in CI.
 #  - benchmarks/**  throwaway dev/prototype scripts, not part of the package or
 #                   the test suite, so lint findings there are not worth chasing.
+#  - data/**        case-study bundles: the builder and run scripts that reproduce a
+#                   published result. They are pinned to the paper they belong to and
+#                   several are byte-identical to a copy in the paper's own repository,
+#                   so reformatting them to satisfy a linter would break the thing that
+#                   makes them useful. Same reasoning as benchmarks/**: not part of the
+#                   package, not part of the test suite.
 exclude_paths:
   - 'tests/**'
   - 'benchmarks/**'
+  - 'data/**'

--- a/data/H2VPPFCR/README.md
+++ b/data/H2VPPFCR/README.md
@@ -24,9 +24,12 @@ H2VPPFCR/
   build_prices_year.py              # day-ahead + FCR capacity price series -> inputs/real_data/year
   build_wind_se3_year.py            # ERA5 -> site wind capacity factor
   build_kappa_year.py              # Nordic frequency record -> FCR activation duties
+  run_year.py                       # solves one case: builds it, solves it, writes the summary
   run_resp_campaign_parallel.py     # runs the 14 headline cases + the S6-S9 spokes (carries the flags)
   run_resp_figs_parallel.py         # figure-data runs (heatmap, erosion, cycling)
   run_p4_spokes_parallel.py         # extra robustness spokes
+  run_sweep.py                      # runs a sweep spec: one solve per cell
+  sweeps/                           # the sweep specs, one JSON per multi-cell result
   comillas_combined_campaign_eur.cmd  comillas_fcr_erosion_eur.cmd  comillas_heatmap_eur.cmd
   data_sources.md  data_sources.bib # provenance for every techno-economic and market figure
   inputs/
@@ -86,6 +89,40 @@ headline cases are solved as the **linear relaxation** (`LP=1`) with **Gurobi**
 (barrier, `BarHomogeneous=1`, `NumericFocus=3`); the full-year instance is 3.2–5.0
 million rows and solves in tens of minutes each.
 
+## Run the sweeps
+
+Not every result in the paper is a single case. Six are sweeps — the same case solved
+once per cell, with one or two environment knobs changed per cell — and each is defined
+by a spec under `sweeps/`:
+
+```bash
+python run_sweep.py sweeps/m2_gates_year.json              # sequential
+python run_sweep.py sweeps/m3b_h2price_year.json --parallel 3
+```
+
+| Spec | Cells | What it produces in the paper |
+|---|---|---|
+| `m2_gates_year.json` | baseline, gatesoff | the deliverability decomposition behind contribution 1: switching the endurance and ramp gates off leaves the build unchanged and moves the objective by 0.1% |
+| `m4_windcapex_year.json` | wind capex 860 / 1434 EUR/kW | case S10, wind capital cost plus or minus 25% |
+| `m3b_h2price_year.json` | hydrogen price 1.0 to 0.0 | the hydrogen-price sensitivity figure |
+| `b1_pemmenu_year.json` | PEM menu 9 / 15 / 21 MW | case S11, the widened electrolyser menu |
+| `fcr_erosion_year.json` | FCR price 1.0 to 0.0 | the FCR price-erosion figure |
+| `heatmap_month.json` | degradation x hydrogen price | the two-way sensitivity heatmap |
+
+The `m1_foresight_month.json` and `m7a_*.json` specs cover the month-horizon checks
+reported in the text: the cost of committing the reserve bids ahead of the day-ahead
+outcome, and the cost of integer commitment against the linear relaxation.
+
+A spec sets a `base_env` shared by every cell and then one `env` override per cell, so
+the difference between two cells is exactly what the JSON says it is. Cells are solved
+by `run_year.py`, the same script the campaign runners call, so a sweep cell and a
+campaign case are solved identically.
+
+Three cells of `m3b_h2price_year.json` (hydrogen price 0.20, 0.10 and 0.05) hit the time
+limit rather than proving optimality. They sit inside the collapse zone where the
+electrolyser build has already gone to zero and the curve is monotone through them, so
+the paper does not rely on them.
+
 ## Notes
 
 - **Currency.** Regulatory charges are set in SEK; the case is emitted and the
@@ -95,3 +132,9 @@ million rows and solves in tens of minutes each.
   `build_case.py` at the paper's model commit; regenerate it against this release
   tag before relying on byte-identity, since the builder evolves with the model.
 - Build outputs (`oM_Result_*`, `*.lp`, `*.log`, `*.sol`) are git-ignored.
+- **Where results land.** `run_year.py` writes the built case and the results under the
+  repository root by default. Set `H2VPP_OUTBASE` to send both somewhere else.
+- **Conditioning probe.** `CONDITIONING=1` or `KAPPA=1` makes `run_year.py` report the
+  constraint-matrix and variable-bound coefficient ranges. It loads `analysis/conditioning.py`
+  from the paper's companion repository and is off by default, so it is not needed to
+  reproduce any result here.

--- a/data/H2VPPFCR/run_p4_spokes_parallel.py
+++ b/data/H2VPPFCR/run_p4_spokes_parallel.py
@@ -21,9 +21,10 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+HERE = Path(__file__).resolve().parent
 REPO = Path(__file__).resolve().parents[2]
 PY = sys.executable
-RUN_YEAR = REPO / "experiments" / "h2vpp_fcr" / "run_year.py"
+RUN_YEAR = HERE / "run_year.py"
 LOGDIR = REPO / "results" / "p4_spokes"
 LOGDIR.mkdir(parents=True, exist_ok=True)
 

--- a/data/H2VPPFCR/run_resp_campaign_parallel.py
+++ b/data/H2VPPFCR/run_resp_campaign_parallel.py
@@ -20,9 +20,10 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+HERE = Path(__file__).resolve().parent
 REPO = Path(__file__).resolve().parents[2]
 PY = sys.executable
-RUN_YEAR = REPO / "experiments" / "h2vpp_fcr" / "run_year.py"
+RUN_YEAR = HERE / "run_year.py"
 LOGDIR = REPO / "results" / "resp_campaign"
 LOGDIR.mkdir(parents=True, exist_ok=True)
 

--- a/data/H2VPPFCR/run_resp_figs_parallel.py
+++ b/data/H2VPPFCR/run_resp_figs_parallel.py
@@ -25,9 +25,10 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+HERE = Path(__file__).resolve().parent
 REPO = Path(__file__).resolve().parents[2]
 PY = sys.executable
-RUN_YEAR = REPO / "experiments" / "h2vpp_fcr" / "run_year.py"
+RUN_YEAR = HERE / "run_year.py"
 LOGDIR = REPO / "results" / "p4_figs"
 LOGDIR.mkdir(parents=True, exist_ok=True)
 

--- a/data/H2VPPFCR/run_sweep.py
+++ b/data/H2VPPFCR/run_sweep.py
@@ -1,0 +1,460 @@
+"""H2VPP FCR sweep runner -- the case ADAPTER for el1xr_opt.sweep.
+
+The three sweep modes (A cold registry / B overlay-parallel / C warm hot-swap) now live in the
+reusable el1xr_opt.sweep package; this file is the H2VPP-specific part: how a cell becomes a
+solved summary via build_case.py + run_year.py. The spec JSON format and CLI are unchanged:
+
+    python experiments/h2vpp_fcr/run_sweep.py <spec.json> [--force]        # Mode A
+    python experiments/h2vpp_fcr/run_sweep.py <spec.json> --parallel <N>   # Mode B
+    python experiments/h2vpp_fcr/run_sweep.py <spec.json> --warm           # Mode C
+    python experiments/h2vpp_fcr/run_sweep.py <spec.json> --validate <tag> [--parallel N]
+
+Case specifics kept here:
+  * _cell_env / _work_name -- the env-knob + work-dir convention run_year.py uses.
+  * Mode A / B -- run_year.py subprocesses; Mode B builds the case once and reproduces each
+    cell by scaling a fixed input-column set (_OVERLAY_MAP, proven an exact uniform scaling),
+    solving cells in parallel via run_year's SWEEP_PREBUILT_WORK build-skip.
+  * Mode C -- gurobi_persistent build-once + chgCoeff on the FCR revenue coefficient family
+    (_FCR_REV_CONS); _apply_run_year_post_build_edits replays ELE_RAMP_CAP so the warm model
+    equals the cold one; validation_base_override forces Crossover=1 so the degenerate LP's
+    capacity check is a vertex-vs-vertex comparison.
+"""
+import os
+import sys
+import json
+import shutil
+import datetime
+import subprocess
+import importlib.util
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+# el1xr_opt sits at model/src in the paper's companion repo and at src/ in el1xr_opt
+# itself, so this file is the same in both; an installed package wins over both.
+for _cand in (REPO / "model" / "src", REPO / "src"):
+    if (_cand / "el1xr_opt").is_dir():
+        sys.path.insert(0, str(_cand))
+        break
+from el1xr_opt.sweep import SweepAdapter, Summary, WarmSession, main as sweep_main
+
+RESULTS = REPO / "results" / "h2vpp_fcr"
+RUN_YEAR = HERE / "run_year.py"
+CASE = "H2VPPFCR"
+# Interpreter for the run_year subprocesses; default the one running this script (invoke with
+# the el1xr_opt venv python so children get pyomo/solvers).
+PYTHON = os.environ.get("SWEEP_PYTHON", sys.executable)
+
+# Option flags patched into the work-dir Option CSV (same mapping as run_year.py).
+_OPT_ENV = {"PEAK_THRESHOLD_LP": "IndPeakThresholdLP", "STOR_FCR_LEG": "IndStorFCRLegExclusive",
+            "ELE_3STATE_TIGHT": "IndElectrolyser3StateTight",
+            "ELE_OPER_SYMBREAK": "IndElectrolyserOperSymBreak",
+            "ELE_PWL_RELAX": "IndElectrolyserPWLRelax",
+            "RESERVE_DELIVERY": "IndReserveDeliverySettlement"}
+
+# Mode C coefficient family: the three FCR revenue-defining constraints + the revenue variable
+# each defines. Every other variable in those rows is a bid with an FCR price coefficient.
+_FCR_REV_CONS = (("eEleMarketFCRDUpRevenue", "vTotalEleFCRDUpRev"),
+                 ("eEleMarketFCRDDwRevenue", "vTotalEleFCRDDwRev"),
+                 ("eEleMarketFCRNRevenue", "vTotalEleFCRNRev"))
+
+# Mode B overlay map: each sweep knob is an EXACT uniform scaling of a fixed set of
+# (built-input file, columns), verified by diffing build_case outputs. Files carry {CASE}.
+_OVERLAY_MAP = {
+    "DEG_SCALE": [("oM_Data_HydrogenGeneration_{CASE}.csv",
+                   ["DegradationCost", "DegradationCost2ndBlock", "RampDegradationCost"])],
+    "H2_PRICE_SCALE": [("oM_Data_HydrogenDemand_{CASE}.csv", ["Price"])],
+    "FCR_PRICE_SCALE": [("oM_Data_OperatingReservePrice_{CASE}.csv",
+                         ["FCRD_Up", "FCRD_Down", "FCRN_Up", "FCRN_Down"])],
+}
+
+
+# --------------------------------------------------------------------------
+# env-knob + work-dir convention (matches run_year.py)
+# --------------------------------------------------------------------------
+
+def _cell_env(spec, cell):
+    """Merged env for one cell: base + cell params + variant/horizon/RUN_TAG."""
+    env = dict(spec.base)
+    env.update(cell.params)
+    if spec.case.get("variant"):
+        env["VARIANT"] = spec.case["variant"]
+    if spec.case.get("horizon"):
+        env["H2VPP_HORIZON"] = spec.case["horizon"]
+    env["RUN_TAG"] = cell.tag
+    return {k: str(v) for k, v in env.items()}
+
+
+def _work_name(env):
+    """run_year.py's work-dir naming rule, so the adapter finds each cell's summary."""
+    hz = env.get("H2VPP_HORIZON", "year")
+    variant = env.get("VARIANT", "").upper()
+    if variant:
+        base = f"work_{hz}_{variant}"
+    else:
+        mode = (env.get("H2VPP_DEMAND_MODE")
+                or ("firm" if env.get("FIRM") == "1" else "elastic")).lower()
+        base = f"work_{hz}" + {"elastic": "", "firm": "_firm", "shift": "_shift"}.get(mode, f"_{mode}")
+    return f"{base}_{env['RUN_TAG']}"
+
+
+def _envn(env, name, default, cast=float):
+    v = env.get(name)
+    return cast(v) if v not in (None, "") else default
+
+
+def _run_year(env, log_path):
+    """Run run_year.py as a subprocess with this cell's env; return its returncode."""
+    with open(log_path, "w") as lf:
+        p = subprocess.run([PYTHON, str(RUN_YEAR)], env={**os.environ, **env},
+                           cwd=str(REPO), stdout=lf, stderr=subprocess.STDOUT)
+    return p.returncode
+
+
+def _summary_to_normalised(d):
+    """Map a run_year summary dict into the sweep package's Summary."""
+    caps = {**(d.get("ele_build") or {}), **(d.get("hyd_build") or {}), **(d.get("comp_build") or {})}
+    if d.get("ele_conn_cap_MW") is not None:
+        caps["ele_conn_cap_MW"] = d["ele_conn_cap_MW"]
+    return Summary(objective=d.get("eTotalSCost_SEK"), capacities=caps,
+                   termination=d.get("termination"), raw=d)
+
+
+# --------------------------------------------------------------------------
+# Mode B: build once + overlay
+# --------------------------------------------------------------------------
+
+def _materialize_base(spec):
+    """Build the case ONCE with every overlay knob forced to 1.0, patch the Option CSV, and
+    return the base input dir. Cells reproduce their cold build by scaling overlay columns."""
+    import pandas as pd
+    env = dict(spec.base)
+    for knob in _OVERLAY_MAP:
+        env[knob] = "1.0"
+    if spec.case.get("variant"):
+        env["VARIANT"] = spec.case["variant"]
+    if spec.case.get("horizon"):
+        env["H2VPP_HORIZON"] = spec.case["horizon"]
+    env.pop("RUN_TAG", None)
+    env = {k: str(v) for k, v in env.items()}
+    os.environ.update(env)
+    mspec = importlib.util.spec_from_file_location("bc_modeb", HERE / "build_case.py")
+    bc = importlib.util.module_from_spec(mspec)
+    mspec.loader.exec_module(bc)
+    bc.OUT_DIR = HERE / "inputs" / f"{CASE}__build_modeb_base_{spec.name}"
+    print(f"Mode B: building {CASE} {bc.HORIZON} base once (overlay knobs = 1.0) "
+          f"-> {bc.OUT_DIR.name} ...", flush=True)
+    bc.build()
+    opt_set = {col: int(os.environ[ev]) for ev, col in _OPT_ENV.items()
+               if os.environ.get(ev) is not None}
+    if opt_set:
+        optf = bc.OUT_DIR / f"oM_Data_Option_{CASE}.csv"
+        od = pd.read_csv(optf)
+        for col, v in opt_set.items():
+            od[col] = v
+        od.to_csv(optf, index=False)
+        print(f"Mode B: option overrides {opt_set} -> {optf.name}", flush=True)
+    return bc.OUT_DIR
+
+
+def _apply_overlays(case_dir, env):
+    """Scale the overlay columns in case_dir by this cell's knob values (base is at knob=1.0)."""
+    import pandas as pd
+    for knob, targets in _OVERLAY_MAP.items():
+        factor = float(env.get(knob, "1.0") or "1.0")
+        if factor == 1.0:
+            continue
+        for fname, cols in targets:
+            fp = case_dir / fname.format(CASE=CASE)
+            if not fp.exists():
+                continue
+            df = pd.read_csv(fp)
+            for c in cols:
+                if c in df.columns:
+                    df[c] = df[c] * factor
+            df.to_csv(fp, index=False)
+
+
+# --------------------------------------------------------------------------
+# Mode C: gurobi_persistent warm session
+# --------------------------------------------------------------------------
+
+def _gurobi_ok():
+    try:
+        import gurobipy
+        genv = gurobipy.Env(params={"OutputFlag": 0})
+        gurobipy.Model(env=genv).dispose()
+        genv.dispose()
+        return True
+    except Exception as exc:
+        print(f"gurobi not usable here: {exc}", flush=True)
+        return False
+
+
+def _apply_run_year_post_build_edits(m):
+    """Replay run_year.py's env-gated model edits that come AFTER build_model. ELE_RAMP_CAP is
+    the one that matters for the price sweep (MIN_BID_FLOOR/FIX_INVEST are refused in
+    warm_eligible). Keep in lockstep with run_year.py."""
+    import pyomo.environ as pyo
+    if os.environ.get("ELE_RAMP_CAP") == "1":
+        rho = {"AEL": float(os.environ.get("AEL_RAMP_PCTS", "2.0")) / 100.0,
+               "PEM": float(os.environ.get("PEM_RAMP_PCTS", "10.0")) / 100.0}
+        fac = 7.5 / 0.86
+        m.elerampcap = pyo.Block()
+
+        def _ramp(b, p, sc, n, u):
+            tech = "AEL" if "AEL" in u else ("PEM" if "PEM" in u else None)
+            if tech is None:
+                return pyo.Constraint.Skip
+            return m.vEleFreqContReserveDisUpwardBid[p, sc, n, u] \
+                <= rho[tech] * fac * m.Par["pHydMaxCharge"][u][p, sc, n] * m.vHydGenInvest[u]
+        m.elerampcap.cap = pyo.Constraint(m.psne2h, rule=_ramp)
+        print(f"warm: ELE_RAMP_CAP FCR-D-up ramp cap (AEL {rho['AEL']*100:.1f}%/s, "
+              f"PEM {rho['PEM']*100:.1f}%/s)", flush=True)
+
+
+def _build_warm_model(spec, anchor_env):
+    """Build the case + Pyomo model once, the way run_year.py does, at FCR_PRICE_SCALE=1.0."""
+    env = dict(anchor_env)
+    env.pop("RUN_TAG", None)
+    env["FCR_PRICE_SCALE"] = "1.0"
+    os.environ.update(env)
+    mspec = importlib.util.spec_from_file_location("bc_sweep", HERE / "build_case.py")
+    bc = importlib.util.module_from_spec(mspec)
+    mspec.loader.exec_module(bc)
+    bc.OUT_DIR = HERE / "inputs" / f"{CASE}__build_warm_{spec.name}"
+    print(f"warm: building {CASE} {bc.HORIZON} case once (FCR_PRICE_SCALE=1.0) "
+          f"-> {bc.OUT_DIR.name} ...", flush=True)
+    bc.build()
+
+    warm_work = RESULTS / f"sweep_{spec.name}" / "warm_model"
+    wc = warm_work / CASE
+    if wc.exists():
+        shutil.rmtree(wc)
+    wc.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(bc.OUT_DIR, wc)
+    opt_set = {col: int(os.environ[ev]) for ev, col in _OPT_ENV.items()
+               if os.environ.get(ev) is not None}
+    if opt_set:
+        import pandas as pd
+        optf = wc / f"oM_Data_Option_{CASE}.csv"
+        od = pd.read_csv(optf)
+        for col, v in opt_set.items():
+            od[col] = v
+        od.to_csv(optf, index=False)
+        print(f"warm: option overrides {opt_set} -> {optf.name}", flush=True)
+
+    import pyomo.environ as pyo
+    from el1xr_opt.Modules.oM_Sequence import build_model
+    now = datetime.datetime.now().replace(second=0, microsecond=0)
+    m = build_model(str(warm_work), CASE, now, "False")
+    pyo.TransformationFactory("core.relax_integer_vars").apply_to(m)
+    print("warm: LP=1, relaxed integer/binary vars to continuous", flush=True)
+    _apply_run_year_post_build_edits(m)
+    return bc, m, warm_work
+
+
+def _fcr_price_rows(m, opt):
+    """Base (scale-1.0) FCR price coefficients as (gurobi_con, gurobi_var, coeff) triples: every
+    variable in the FCR revenue rows except the revenue variable each row defines."""
+    grb = opt._solver_model
+    grb.update()
+    con_map = opt._pyomo_con_to_solver_con_map
+    var_map = opt._pyomo_var_to_solver_var_map
+    rows = []
+    for cname, vname in _FCR_REV_CONS:
+        con = getattr(m, cname, None)
+        rev = getattr(m, vname, None)
+        if con is None or rev is None:
+            continue
+        for idx in con:
+            gcon = con_map[con[idx]]
+            gskip = var_map[rev[idx]]
+            row = grb.getRow(gcon)
+            for j in range(row.size()):
+                gv = row.getVar(j)
+                if gv.sameAs(gskip):
+                    continue
+                rows.append((gcon, gv, row.getCoeff(j)))
+    return rows
+
+
+def _warm_summary(m, bc, tc, env):
+    """The summary fields run_year.py writes, extracted from the in-process model."""
+    import pyomo.environ as pyo
+    f1 = float(m.factor1)
+    mb = float(env.get("MONEY_BASE", "1.0"))
+    val = lambda v: float(pyo.value(v))
+    phys = lambda x: x / f1
+    summary = {"case": CASE, "variant": bc.VARIANT or "A3", "mode": bc.DEMAND_MODE,
+               "firm": bc.DEMAND_MODE == "firm", "horizon": bc.HORIZON, "factor1": f1,
+               "money_base": mb, "hnscost": bc.HNSCOST, "termination": tc,
+               "method": "warm_gurobi_persistent",
+               "eTotalSCost_SEK": val(m.eTotalSCost) * mb}
+    try:
+        summary["peak_cost_SEK"] = sum(val(m.vTotalElePeakCost[i]) for i in m.vTotalElePeakCost) * mb
+    except Exception:
+        summary["peak_cost_SEK"] = None
+    summary["HNS_total_kgH2"] = phys(sum(val(m.vHNS[i]) for i in m.vHNS))
+    summary["H2_demand_served_kgH2"] = phys(sum(val(m.vHydDemand[i]) for i in m.vHydDemand))
+    summary["H2_import_buy_kgH2"] = phys(sum(val(m.vHydBuy[i]) for i in m.vHydBuy))
+    summary["ele_build"] = {u: val(m.vEleGenInvest[u]) for u in m.egc}
+    summary["hyd_build"] = {u: val(m.vHydGenInvest[u]) for u in m.hgc}
+    summary["comp_build"] = {u: val(m.vHydCompInvest[u]) for u in m.hgcompc}
+    try:
+        summary["ele_conn_cap_MW"] = phys(val(m.vEleConnCap)) / 1000.0 if hasattr(m, "vEleConnCap") else None
+    except Exception:
+        summary["ele_conn_cap_MW"] = None
+    fcr_vars = {"vEleFreqContReserveDisUpwardBid": "FCR-D up",
+                "vEleFreqContReserveDisDownwardBid": "FCR-D down",
+                "vEleFreqContReserveNorBid": "FCR-N"}
+    fcr = {}
+    for vn, label in fcr_vars.items():
+        comp = getattr(m, vn, None)
+        if comp is None:
+            continue
+        by_asset = {}
+        for idx in comp:
+            by_asset[idx[-1]] = by_asset.get(idx[-1], 0.0) + val(comp[idx])
+        fcr[label] = by_asset
+    summary["fcr_sum_by_asset"] = fcr
+    return summary
+
+
+class _FCRWarmSession(WarmSession):
+    """Build the FCR model once on gurobi_persistent; each cell re-scales the FCR price
+    coefficient family in place and re-solves (barrier+crossover on the first cell for a basis,
+    dual simplex from that basis after)."""
+
+    def __init__(self, spec):
+        from pyomo.opt import SolverFactory
+        self.spec = spec
+        anchor_env = _cell_env(spec, spec.cells[0])
+        self.bc, self.m, self.warm_work = _build_warm_model(spec, anchor_env)
+        self.opt = SolverFactory("gurobi_persistent")
+        self.opt.set_instance(self.m)
+        self.rows = _fcr_price_rows(self.m, self.opt)
+        self.grb = self.opt._solver_model
+        print(f"warm: captured {len(self.rows)} FCR price coefficients across the "
+              f"{len(_FCR_REV_CONS)} revenue constraint families", flush=True)
+        e0 = anchor_env
+        self.base_opts = dict(Presolve=_envn(e0, "PRESOLVE", 2, int),
+                              NumericFocus=_envn(e0, "NUMERICFOCUS", 2, int),
+                              FeasibilityTol=_envn(e0, "FEASTOL", 1e-6),
+                              TimeLimit=_envn(e0, "TIMELIMIT", 21600, int))
+        if e0.get("THREADS"):
+            self.base_opts["Threads"] = int(e0["THREADS"])
+        if e0.get("SCALEFLAG") not in (None, ""):
+            self.base_opts["ScaleFlag"] = int(e0["SCALEFLAG"])
+        if e0.get("BARHOMOGENEOUS") not in (None, ""):
+            self.base_opts["BarHomogeneous"] = int(e0["BARHOMOGENEOUS"])
+        self.have_basis = False
+
+    def solve_cell(self, cell, first):
+        env = _cell_env(self.spec, cell)
+        s = float(env.get("FCR_PRICE_SCALE", "1.0"))
+        for gcon, gvar, c0 in self.rows:
+            self.grb.chgCoeff(gcon, gvar, c0 * s)
+        self.opt.options.update(self.base_opts)
+        if self.have_basis:
+            self.opt.options["Method"] = 1              # dual simplex from the previous basis
+        else:
+            self.opt.options["Method"] = _envn(env, "METHOD", 2, int)
+            self.opt.options["Crossover"] = 1           # anchor: leave a basis to warm-start from
+        self.opt.options["LogFile"] = str(self.warm_work / f"gurobi_{CASE}_{cell.tag}.log")
+        try:
+            res = self.opt.solve(save_results=False, tee=False)
+            tc = str(res.solver.termination_condition)
+        except Exception as exc:
+            tc = f"error: {type(exc).__name__}: {exc}"
+        if tc == "optimal":
+            raw = _warm_summary(self.m, self.bc, tc, env)
+            raw["fcr_price_scale"] = s
+            self.have_basis = True
+            return _summary_to_normalised(raw)
+        return Summary(objective=None, capacities={}, termination=tc, raw={})
+
+
+# --------------------------------------------------------------------------
+# The adapter
+# --------------------------------------------------------------------------
+
+class H2VPPAdapter(SweepAdapter):
+    """Binds el1xr_opt.sweep to this experiment's build_case.py + run_year.py."""
+
+    def summary_path(self, spec, cell):
+        return RESULTS / _work_name(_cell_env(spec, cell)) / f"summary_{CASE}.json"
+
+    def read_summary(self, path):
+        return _summary_to_normalised(json.loads(Path(path).read_text()))
+
+    def workname(self, spec, cell):
+        return _work_name(_cell_env(spec, cell))
+
+    def validation_base_override(self):
+        # degenerate LP: force a vertex on both sides so the capacity check is meaningful;
+        # fall back to HiGHS when no Gurobi licence is present (local dev).
+        return {"CROSSOVER": "1", "SOLVER": "gurobi" if _gurobi_ok() else "highs"}
+
+    def validation_case_override(self):
+        return {"horizon": "week"}   # validate on the cheap horizon
+
+    # Mode A
+    def solve_cold(self, spec, cell, log_path, threads=None):
+        env = _cell_env(spec, cell)
+        if threads:
+            env["THREADS"] = str(threads)
+        return _run_year(env, log_path)
+
+    # Mode B
+    def overlay_eligible(self, spec):
+        unmapped = spec.varying_params() - set(_OVERLAY_MAP)
+        if unmapped:
+            return False, (f"cells vary in {sorted(unmapped)}, not overlay-mappable "
+                           f"(only {sorted(_OVERLAY_MAP)} scale a fixed input-column set)")
+        return True, ""
+
+    def materialize_base(self, spec):
+        return _materialize_base(spec)
+
+    def prepare_overlay_cell(self, spec, base, cell):
+        env = _cell_env(spec, cell)
+        work = self.summary_path(spec, cell).parent
+        wc = work / CASE
+        if wc.exists():
+            shutil.rmtree(wc)
+        wc.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(base, wc)
+        _apply_overlays(wc, env)
+        return work
+
+    def solve_prebuilt(self, spec, cell, workdir, log_path, threads=None):
+        env = _cell_env(spec, cell)
+        env["SWEEP_PREBUILT_WORK"] = str(workdir)
+        if threads:
+            env["THREADS"] = str(threads)
+        return _run_year(env, log_path)
+
+    # Mode C
+    def warm_eligible(self, spec):
+        bad = spec.varying_params() - {"FCR_PRICE_SCALE"}
+        if bad:
+            return False, (f"cells vary in {sorted(bad)} (only FCR_PRICE_SCALE maps to a single "
+                           f"objective-coefficient family; other knobs run cold)")
+        env = _cell_env(spec, spec.cells[0])
+        if env.get("LP") != "1":
+            return False, "warm start needs the LP relaxation (set LP=1 in base_env)"
+        if float(env.get("MIN_BID_FLOOR", "0") or "0") > 0:
+            return False, "MIN_BID_FLOOR adds binaries (a MIP); the warm path is LP-only"
+        if env.get("FIX_INVEST"):
+            return False, "FIX_INVEST fixes the sizing (anchor run), not a price sweep"
+        if not _gurobi_ok():
+            return False, "no usable Gurobi licence (gurobi_persistent)"
+        return True, ""
+
+    def open_warm(self, spec):
+        return _FCRWarmSession(spec)
+
+
+if __name__ == "__main__":
+    sys.exit(sweep_main(H2VPPAdapter(), RESULTS))

--- a/data/H2VPPFCR/run_year.py
+++ b/data/H2VPPFCR/run_year.py
@@ -1,0 +1,563 @@
+"""Full-year (8736 h) H2VPP FCR run for the Comillas remote desktop (Gurobi).
+
+Regenerates the case at the year horizon from the real 2025 data, solves on Gurobi,
+and writes a results summary. Heavy: this is a year-long investment+commitment MILP,
+intended for a workstation with Gurobi, not a laptop.
+
+Usage (from the repo root, with the el1xr_opt env active and PYTHONPATH=model/src):
+    H2VPP_HORIZON=year python experiments/h2vpp_fcr/run_year.py
+
+Environment knobs (all optional):
+    H2VPP_HORIZON   week | month | year      (default year here; set by this script)
+    FIRM            1 to make the HRS demand a firm must-serve contract (default 0)
+    TIMELIMIT       Gurobi seconds            (default 21600 = 6 h)
+    MIPGAP          target relative gap       (default 0.01)
+    THREADS         Gurobi threads            (default: all cores)
+"""
+import os, sys, json, shutil, datetime, importlib.util
+from pathlib import Path
+
+os.environ.setdefault("H2VPP_HORIZON", "year")
+FIRM = os.environ.get("FIRM", "0") == "1"
+TIMELIMIT = int(os.environ.get("TIMELIMIT", "21600"))
+MIPGAP = float(os.environ.get("MIPGAP", "0.01"))
+THREADS = os.environ.get("THREADS")
+
+REPO = Path(__file__).resolve().parents[2]
+# el1xr_opt sits at model/src in the paper's companion repo and at src/ in el1xr_opt
+# itself, so this file is the same in both; an installed package wins over both.
+for _cand in (REPO / "model" / "src", REPO / "src"):
+    if (_cand / "el1xr_opt").is_dir():
+        sys.path.insert(0, str(_cand))
+        break
+
+# --- regenerate the case at the year horizon ---
+spec = importlib.util.spec_from_file_location("bc_year", Path(__file__).resolve().parent / "build_case.py")
+bc = importlib.util.module_from_spec(spec); spec.loader.exec_module(bc)
+# Horizon comes from H2VPP_HORIZON (week | month | year). Year is the headline solve;
+# week/month are for validation that the case builds and solves on this machine.
+HZ = bc.HORIZON
+CASE = bc.CASE
+# Demand mode (elastic | firm | quota) is owned by build_case.py, driven by the same env
+# (H2VPP_DEMAND_MODE, or FIRM=1 -> firm). Read it back here for the work dir and summary.
+MODE = bc.DEMAND_MODE
+
+# SWEEP_PREBUILT_WORK=<dir>: the Mode B sweep runner has already built the case once and
+# written this cell's (overlaid) inputs into <dir>/<CASE>. Skip build_case + the copy and
+# solve that work dir as-is. Everything downstream (Option patch, build_model, post-build
+# edits, solve, summary) is identical, so the solve path stays single-sourced in this file.
+PREBUILT = os.environ.get("SWEEP_PREBUILT_WORK")
+
+# OUT_BASE redirects the (large) build + results output to another disk (e.g. D:\h2vpp_work on the
+# Comillas box, which has far more free space than C:). Unset = the default in-repo layout, so
+# existing/local runs are unchanged. When set, builds go to <OUT_BASE>\inputs and results to
+# <OUT_BASE>\results\h2vpp_fcr.
+_OUTBASE = os.environ.get("OUT_BASE")
+_BUILD_BASE   = (Path(_OUTBASE) / "inputs")            if _OUTBASE else (REPO / "experiments" / "h2vpp_fcr" / "inputs")
+_RESULTS_BASE = (Path(_OUTBASE) / "results" / "h2vpp_fcr") if _OUTBASE else (REPO / "results" / "h2vpp_fcr")
+
+# Build into a PER-VARIANT inputs dir, not the shared inputs/<CASE>. build_case writes the
+# case CSVs to bc.OUT_DIR; under a parallel runner two jobs building into the same shared
+# path race and clobber each other's inputs (observed: A2 and B0 solved identical problems).
+# A per-variant OUT_DIR isolates each job's build. RUN_TAG keeps sweep points distinct too.
+VARIANT = bc.VARIANT
+if not PREBUILT:
+    _buildtag = f"{VARIANT}" if VARIANT else MODE
+    _buildtag += f"_{os.environ.get('RUN_TAG','')}" if os.environ.get("RUN_TAG") else ""
+    _BUILD_BASE.mkdir(parents=True, exist_ok=True)
+    bc.OUT_DIR = _BUILD_BASE / f"{CASE}__build_{_buildtag}"
+    print(f"building {CASE} {HZ} case (factor1={bc.FACTOR1}, HNSCost={bc.HNSCOST}, mode={MODE}, "
+          f"N_LOADLEVELS={bc.N_LOADLEVELS}) -> {bc.OUT_DIR.name} ...", flush=True)
+    bc.build()
+
+# --- solve on Gurobi in a clean work dir (one per horizon/variant, else per demand mode) ---
+_modesuffix = {"elastic": "", "firm": "_firm", "shift": "_shift"}.get(MODE, f"_{MODE}")
+work_name = f"work_{HZ}_{VARIANT}" if VARIANT else f"work_{HZ}{_modesuffix}"
+# Optional tag to keep sweep points (e.g. degradation-cost scale) in distinct work dirs.
+RUN_TAG = os.environ.get("RUN_TAG", "")
+if RUN_TAG:
+    work_name += f"_{RUN_TAG}"
+if PREBUILT:
+    work = Path(PREBUILT)
+    wc = work / CASE
+    print(f"SWEEP_PREBUILT_WORK: solving prebuilt inputs at {work} (build skipped)", flush=True)
+else:
+    work = _RESULTS_BASE / work_name
+    wc = work / CASE
+    if wc.exists():
+        shutil.rmtree(wc)
+    wc.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(bc.OUT_DIR, wc)   # per-variant build dir (race-safe under parallel runners)
+
+# Optional feature flags patched into the work-dir Option CSV by env knob so build_model picks
+# them up. All default unset = existing behaviour. PEAK_THRESHOLD_LP -> exact binary-free CVaR
+# peak charge; STOR_FCR_LEG -> leg-exclusive storage FCR (closes the simultaneous
+# charge+discharge reserve loophole).
+_opt_env = {"PEAK_THRESHOLD_LP": "IndPeakThresholdLP", "STOR_FCR_LEG": "IndStorFCRLegExclusive",
+            "ELE_3STATE_TIGHT": "IndElectrolyser3StateTight",
+            "ELE_OPER_SYMBREAK": "IndElectrolyserOperSymBreak",
+            "ELE_PWL_RELAX": "IndElectrolyserPWLRelax",
+            "RESERVE_DELIVERY": "IndReserveDeliverySettlement"}
+_opt_set = {col: int(os.environ[ev]) for ev, col in _opt_env.items() if os.environ.get(ev) is not None}
+if _opt_set:
+    import pandas as _pd
+    _optf = wc / f"oM_Data_Option_{CASE}.csv"
+    _od = _pd.read_csv(_optf)
+    for _col, _v in _opt_set.items():
+        _od[_col] = _v
+    _od.to_csv(_optf, index=False)
+    print(f"option overrides {_opt_set} -> {_optf.name}", flush=True)
+
+import pyomo.environ as pyo
+from pyomo.opt import SolverFactory
+from el1xr_opt.Modules.oM_Sequence import build_model
+
+NOW = datetime.datetime.now().replace(second=0, microsecond=0)
+
+# BENDERS=1 solves the INTEGER model by temporal decomposition (investment + storage-boundary
+# inventory in the master, integer operating recourse per time block) instead of the monolith.
+# LP optimality cuts fail on the binary subproblems (no LP duals), so the default cut family is
+# the integer-aware 'lagrangian' (SDDiP-style), which needs a MILP solver with master duals
+# (gurobi). Opt-in and separate from the LP path -- this is the integer-decomposition route.
+if os.environ.get("BENDERS") == "1":
+    from el1xr_opt.Modules.oM_Decomposition import el1xr_temporal_benders, BendersConfig
+    nblocks = int(os.environ.get("BENDERS_BLOCKS", "12"))
+    cut = os.environ.get("BENDERS_CUT", "lagrangian")
+    bsolver = os.environ.get("BENDERS_SOLVER", "gurobi")
+    cfg = BendersConfig(max_iterations=int(os.environ.get("BENDERS_ITERS", "60")),
+                        relative_gap=float(os.environ.get("BENDERS_GAP", "1e-3")))
+    print(f"BENDERS: temporal decomposition (blocks={nblocks}, cut={cut}, solver={bsolver}) ...", flush=True)
+    res = el1xr_temporal_benders(str(work), CASE, NOW, n_time_blocks=nblocks, solver=bsolver,
+                                 config=cfg, cut_mode=cut)
+    summary = {"case": CASE, "variant": VARIANT or "A3", "mode": MODE, "method": "temporal_benders", "cut_mode": cut,
+               "n_blocks": nblocks, "horizon": bc.HORIZON, "factor1": bc.FACTOR1,
+               "converged": res.get("converged"), "objective": res.get("objective"),
+               "lower_bound": res.get("lower_bound"), "gap": res.get("gap"),
+               "iterations": res.get("iterations")}
+    out = work / f"summary_{CASE}.json"
+    out.write_text(json.dumps(summary, indent=2))
+    print("\n" + "=" * 60 + "\n" + json.dumps(summary, indent=2) + "\n" + "=" * 60, flush=True)
+    print(f"summary -> {out}", flush=True)
+    raise SystemExit(0)
+
+m = build_model(str(work), CASE, NOW, "False")
+
+# LP=1 relaxes all integer/binary vars to continuous. For the year horizon the full MILP
+# root relaxation alone takes ~20 min on barrier and the MIP rarely finds an incumbent in
+# hours; the LP relaxation (continuous commitment) is the tractable headline solve and gives
+# the FCR split + sizing directly. Barrier solves it in ~20 min.
+LP = os.environ.get("LP", "0") == "1"
+if LP:
+    pyo.TransformationFactory("core.relax_integer_vars").apply_to(m)
+    print("LP=1: relaxed integer/binary vars to continuous", flush=True)
+
+
+def _envn(name, default, cast=float):
+    v = os.environ.get(name)
+    return cast(v) if v not in (None, "") else default
+
+
+# MIN_BID_FLOOR (MW): market minimum bid size. Enforce a semi-continuous floor on the
+# plant-total reserve bid per product per hour (bid = 0 or >= floor). Needs integrality, so it
+# applies only to the MILP (not LP=1). Adds one binary per product-hour -- keep the horizon short.
+_min_bid = _envn("MIN_BID_FLOOR", 0.0)
+if _min_bid > 0 and not LP:
+    _BIGM = 100.0
+    m.mbfloor = pyo.Block()
+    _nb = 0
+    for _tag, _var in [("DUp", m.vEleFreqContReserveDisUpwardBid),
+                       ("DDn", m.vEleFreqContReserveDisDownwardBid),
+                       ("Nor", m.vEleFreqContReserveNorBid)]:
+        _keys = {}
+        for _idx in _var:
+            _keys.setdefault(tuple(_idx[:3]), []).append(_idx)
+        _psn = list(_keys); _rng = list(range(len(_psn)))
+        _u = pyo.Var(_rng, domain=pyo.Binary)
+        m.mbfloor.add_component(f"u_{_tag}", _u)
+        m.mbfloor.add_component(f"lo_{_tag}", pyo.Constraint(
+            _rng, rule=lambda b, i, _var=_var, _keys=_keys, _psn=_psn, _u=_u:
+            sum(_var[k] for k in _keys[_psn[i]]) >= _min_bid * _u[i]))
+        m.mbfloor.add_component(f"hi_{_tag}", pyo.Constraint(
+            _rng, rule=lambda b, i, _var=_var, _keys=_keys, _psn=_psn, _u=_u:
+            sum(_var[k] for k in _keys[_psn[i]]) <= _BIGM * _u[i]))
+        _nb += len(_psn)
+    print(f"MIN_BID_FLOOR={_min_bid} MW: semi-continuous plant-total bids ({_nb} binaries)", flush=True)
+
+
+# ELE_RAMP_CAP=1: cap each electrolyser's FCR-D-up bid by the reserve it can ramp within the
+# 7.5 s FCR-D window: bid <= rho * (7.5/0.86) * built consumption capacity, rho = load ramp rate.
+# Sources for the assumptions (also to cite in the paper):
+#   - FCR-D full-activation criterion (>=86% within 7.5 s): Nordic TSOs, "Technical Requirements
+#     for FCR Provision in the Nordic Synchronous Area" v1.1 (2025).
+#   - Electrolyser ramp rates rho: AEL ~0.5-5 %/s, PEM ~10 %/s -- Cozzolino & Bella (2024,
+#     Front. Energy Res. 12:1358333) from Bertuccioli et al. (2014). Defaults AEL 2 %/s, PEM 10 %/s.
+#   - Conservative direction: uses the datasheet ramp-UP rate as a proxy; load-DOWN (the upward-FCR
+#     direction) is rectifier-limited and faster -- Dorn et al. (2026, arXiv:2602.20842).
+#   - Min-load FCR headroom (already enforced in the model) & AEL FCR feasibility: Cammann, Alves &
+#     Jaeschke (2024, IECON); QualyGridS (Reissner et al. 2020, Clean Energy 4(4):379).
+# Applies to FCR-D only (FCR-N's 60/180 s window makes a ramp cap non-binding). rho env-tunable.
+if os.environ.get("ELE_RAMP_CAP") == "1":
+    _rho = {'AEL': _envn("AEL_RAMP_PCTS", 2.0) / 100.0, 'PEM': _envn("PEM_RAMP_PCTS", 10.0) / 100.0}
+    _fac = 7.5 / 0.86
+    m.elerampcap = pyo.Block()
+
+    def _ramp(b, p, sc, n, u):
+        tech = 'AEL' if 'AEL' in u else ('PEM' if 'PEM' in u else None)
+        if tech is None:
+            return pyo.Constraint.Skip
+        return m.vEleFreqContReserveDisUpwardBid[p, sc, n, u] \
+            <= _rho[tech] * _fac * m.Par['pHydMaxCharge'][u][p, sc, n] * m.vHydGenInvest[u]
+    m.elerampcap.cap = pyo.Constraint(m.psne2h, rule=_ramp)
+    print(f"ELE_RAMP_CAP: FCR-D-up ramp cap (AEL {_rho['AEL']*100:.1f}%/s, PEM {_rho['PEM']*100:.1f}%/s)", flush=True)
+
+
+# FIX_INVEST=path/to/summary_H2VPPFCR.json: fix every investment variable at the builds of a
+# previous solve (fix-and-solve). Used for the integer-consistency anchor: fix the sizing at
+# the year-LP optimum, then solve the operating problem as a MILP on a shorter horizon. Build
+# fractions are stored raw in the summary; the connection capacity is stored in MW as
+# phys(var)/1000 = var/(factor1*1000), so the inverse is MW * 1000 * factor1.
+if os.environ.get("FIX_INVEST"):
+    _fs = json.loads(Path(os.environ["FIX_INVEST"]).read_text())
+    _nfix = 0
+    for _vr, _key in ((m.vEleGenInvest, "ele_build"), (m.vHydGenInvest, "hyd_build"),
+                      (m.vHydCompInvest, "comp_build")):
+        for _u, _x in (_fs.get(_key) or {}).items():
+            try:
+                _vr[_u].fix(float(_x))
+                _nfix += 1
+            except KeyError:
+                print(f"FIX_INVEST: unit {_u} not an investment candidate here, skipped", flush=True)
+    if hasattr(m, "vEleConnCap") and _fs.get("ele_conn_cap_MW") is not None:
+        m.vEleConnCap.fix(float(_fs["ele_conn_cap_MW"]) * 1000.0 * float(m.factor1))
+        _nfix += 1
+    print(f"FIX_INVEST: fixed {_nfix} investment variables from {os.environ['FIX_INVEST']}", flush=True)
+
+# FIX_RESERVE_SPLIT=path/to/lp_summary.json: pin each asset's per-product month reserve total to
+# the values in that summary's fcr_sum_by_asset, within a tolerance band (FIX_RESERVE_TOL, default
+# 1%). Paired with FIX_INVEST on the fixed-build MILP check, this removes the reserve-split
+# degeneracy: instead of reporting an arbitrary alternate-optimum split, the MILP must reproduce
+# the linear-relaxation's reserve role and we read off whether that role is deliverable under
+# integer commitment and at what cost (infeasible => the LP over-books reserve the units can't
+# sustain with integer commitment).
+_frs = os.environ.get("FIX_RESERVE_SPLIT")
+if _frs:
+    _fd = (json.loads(Path(_frs).read_text()).get("fcr_sum_by_asset") or {})
+    _tol = float(os.environ.get("FIX_RESERVE_TOL", "0.01"))
+    _rscale = float(os.environ.get("FIX_RESERVE_SCALE", "1.0"))
+    _prodmap = {"FCR-D up": getattr(m, "vEleFreqContReserveDisUpwardBid", None),
+                "FCR-D down": getattr(m, "vEleFreqContReserveDisDownwardBid", None),
+                "FCR-N": getattr(m, "vEleFreqContReserveNorBid", None)}
+    # FIX_RESERVE_LEVEL=unit (default) pins each unit's per-product total; =class pins only the
+    # aggregate battery-class vs electrolyser-class total per product -- the latter is the role
+    # (ranking) test: it lets integer commitment reallocate freely within a class but forces the
+    # relaxation's between-class split, so infeasibility means the ROLE itself is not deliverable.
+    _rlevel = os.environ.get("FIX_RESERVE_LEVEL", "unit").lower()
+    def _uclass(u):
+        return "bat" if (u.startswith("BESS") or u.startswith("FC")) else "ele"
+    m.cFixReserveSplit = pyo.ConstraintList()
+    _nrs = 0
+    for _prod, _var in _prodmap.items():
+        if _var is None:
+            continue
+        _byu = {}
+        for _idx in _var:
+            _byu.setdefault(_idx[-1], []).append(_idx)
+        _tgt = _fd.get(_prod) or {}
+        if _rlevel == "class":
+            _groups = {}   # class -> (target_sum, [indices])
+            for _u, _target in _tgt.items():
+                if _u not in _byu:
+                    continue
+                _c = _uclass(_u)
+                _g = _groups.setdefault(_c, [0.0, []])
+                _g[0] += float(_target)
+                _g[1].extend(_byu[_u])
+            _items = [(_c, _g[0], _g[1]) for _c, _g in _groups.items()]
+        else:
+            _items = [(_u, float(_target), _byu[_u]) for _u, _target in _tgt.items() if _u in _byu]
+        for _lbl, _tval, _idxs in _items:
+            _expr = sum(_var[_i] for _i in _idxs)
+            _t = _tval * _rscale
+            m.cFixReserveSplit.add(_expr <= _t * (1.0 + _tol) + 1e-6)
+            if _t * (1.0 - _tol) > 0:
+                m.cFixReserveSplit.add(_expr >= _t * (1.0 - _tol))
+            _nrs += 1
+    print(f"FIX_RESERVE_SPLIT: pinned {_nrs} per-{_rlevel} per-product reserve totals "
+          f"(scale {_rscale:g}, +-{_tol:.1%}) from {_frs}", flush=True)
+
+# COMMIT_AHEAD=1: pin each FCR capacity bid to a flat level over the horizon -- committed on
+# D-2 information, with no tuning to the realised hourly prices. This is the foresight-rent check
+# (reviewer M1): the profit gap to the free-foresight solve bounds the value that perfect price
+# foresight confers on the capacity bids. Each bid variable is tied equal across all time steps
+# within its (period, scenario, unit) group; the optimiser still picks the best flat, deliverable
+# level, and the endurance and ramp gates still bind every hour.
+_ca_mode = os.environ.get("COMMIT_AHEAD", "0").lower()
+if _ca_mode in ("1", "flat", "diurnal"):
+    # flat: one bid level for the whole horizon (most restrictive). diurnal: an hour-of-day
+    # profile repeated over the horizon -- the plant commits a 24 h bid schedule from forecast,
+    # which its predictable diurnal running pattern supports (the fairer committed-ahead).
+    from collections import defaultdict as _dd
+    _bidvars = [getattr(m, _nm) for _nm in
+                ("vEleFreqContReserveDisUpwardBid", "vEleFreqContReserveDisDownwardBid",
+                 "vEleFreqContReserveNorBid") if hasattr(m, _nm)]
+    _diurnal = (_ca_mode == "diurnal")
+    _pos = {}
+    if _diurnal:
+        _all_n = sorted({_idx[2] for _bv in _bidvars for _idx in _bv})
+        _pos = {n: i for i, n in enumerate(_all_n)}
+    m.cCommitAhead = pyo.ConstraintList()
+    _nca = 0
+    for _bv in _bidvars:
+        _grp = _dd(list)
+        for _idx in _bv:
+            _p, _sc, _n, _u = _idx
+            _key = (_p, _sc, _u, _pos[_n] % 24) if _diurnal else (_p, _sc, _u)
+            _grp[_key].append(_n)
+        for _k, _ns in _grp.items():
+            _p, _sc, _u = _k[0], _k[1], _k[2]
+            _ns.sort()
+            _n0 = _ns[0]
+            for _n in _ns[1:]:
+                m.cCommitAhead.add(_bv[_p, _sc, _n, _u] == _bv[_p, _sc, _n0, _u])
+                _nca += 1
+    print(f"COMMIT_AHEAD={_ca_mode}: pinned {len(_bidvars)} FCR bid families "
+          f"({'hour-of-day profile' if _diurnal else 'flat'}; {_nca} tie constraints)", flush=True)
+
+
+S = SolverFactory("gurobi")
+# Solver options are env-tunable. For a MIP, Gurobi IGNORES Crossover=0 (you must use
+# NodeMethod=2 to skip crossover); for a pure LP, Crossover=0 gives the barrier optimum
+# directly and is the fast path. DualReductions=0 makes an unsolved MIP return a definite
+# status instead of the ambiguous "infeasible or unbounded".
+opts = dict(
+    Method=_envn("METHOD", 2, int),
+    Crossover=_envn("CROSSOVER", 0, int),
+    Presolve=_envn("PRESOLVE", 2, int),
+    NumericFocus=_envn("NUMERICFOCUS", 2, int),
+    FeasibilityTol=_envn("FEASTOL", 1e-6),
+    TimeLimit=TIMELIMIT,
+)
+if not LP:
+    opts.update(
+        MIPFocus=_envn("MIPFOCUS", 1, int),
+        NodeMethod=_envn("NODEMETHOD", 2, int),  # barrier at nodes, no crossover
+        DualReductions=_envn("DUALRED", 0, int),
+        MIPGap=MIPGAP,
+    )
+_bh = _envn("BARHOMOGENEOUS", None, int)
+if _bh is not None:
+    opts["BarHomogeneous"] = _bh
+# ScaleFlag tames a large matrix coefficient range (the year LP barrier hit numerical
+# trouble from poor scaling); 2 = aggressive geometric-mean scaling. Env-tunable.
+# PRACTICE (Phase 1, 2026-06-22): with MONEY_BASE=1000 the matrix span is down to ~7.6 oom
+# and Gurobi's default scaling (ScaleFlag=-1) handles it -- leave ScaleFlag UNSET for the
+# headline runs. Reach for ScaleFlag=2 (+ NumericFocus / BarHomogeneous / concurrent) only
+# on a residual hard case, not by default. Per-unit scaling fixes the structure that
+# solver auto-scaling can only approximate; see notes/scalability_conditioning_investigation.md.
+_sf = _envn("SCALEFLAG", None, int)
+if _sf is not None:
+    opts["ScaleFlag"] = _sf
+if THREADS:
+    opts["Threads"] = int(THREADS)
+log = str(work / f"gurobi_{CASE}.log")
+
+
+def _gurobi_solve(method=None, crossover=None, dualred=None, logfile=log):
+    o = dict(opts)
+    if method is not None:
+        o["Method"] = method
+    if crossover is not None:
+        o["Crossover"] = crossover
+    if dualred is not None:
+        o["DualReductions"] = dualred
+    S.options.update(o)
+    print(f"solving on gurobi (opts={o}); log -> {logfile}", flush=True)
+    r = S.solve(m, tee=True, logfile=logfile, load_solutions=False)
+    t = str(r.solver.termination_condition)
+    hs = bool(getattr(r, "solution", None)) and len(r.solution) > 0
+    print(f"termination = {t}", flush=True)
+    return r, t, hs
+
+
+SOLVER = os.environ.get("SOLVER", "gurobi").lower()
+res = None
+if SOLVER == "highs":
+    # Free-solver path for the continuous (LP) model -- used for local sensitivity sweeps
+    # when no Gurobi licence is available. Integer models should still use Gurobi. Reuses all
+    # the summary extraction below (appsi loads the solution straight into the model).
+    from pyomo.contrib.appsi.solvers.highs import Highs
+    from pyomo.contrib.appsi.base import TerminationCondition as _ATC
+    _h = Highs(); _h.config.stream_solver = True; _h.config.time_limit = TIMELIMIT
+    print("solving on HiGHS (appsi); Gurobi options ignored", flush=True)
+    _hr = _h.solve(m)
+    tc = str(_hr.termination_condition)
+    have_sol = _hr.termination_condition == _ATC.optimal
+    if have_sol:
+        _hr.solution_loader.load_vars()
+else:
+    res, tc, have_sol = _gurobi_solve()
+
+# Concurrent fallback (opt out with CONCURRENT_FALLBACK=0). When the primary method returns no
+# usable solution -- e.g. the barrier ends "sub-optimal/numerical" on a badly degenerate LP such
+# as the FCR-N-only case, whose optimum provides no reserve and leaves the reserve constraints
+# slack -- retry once with the concurrent method (3) so primal and dual simplex run alongside the
+# barrier and one of them finishes where the barrier choked. Crossover on + DualReductions off give
+# a clean vertex and a definite status. This solved B1 (year) when barrier and dual simplex alone
+# could not.
+if not have_sol and SOLVER != "highs" and os.environ.get("CONCURRENT_FALLBACK", "1") == "1" and opts.get("Method") != 3:
+    print("no usable solution from primary method; retrying with concurrent (Method=3)", flush=True)
+    res, tc, have_sol = _gurobi_solve(method=3, crossover=1, dualred=0,
+                                      logfile=str(work / f"gurobi_{CASE}_concurrent.log"))
+
+# Load a solution only if Gurobi returned one; otherwise Pyomo raises on an aborted,
+# solutionless result (the firm case hit the time limit with only a bound).
+if have_sol and res is not None:
+    m.solutions.load_from(res)
+
+# --- capture results ---
+f1 = float(m.factor1)
+# Money-base prescale (build_case MONEY_BASE): the solve is in MONEY_BASE-SEK, so multiply the
+# reported objective and bounds back to SEK. Physical quantities (energy, builds, FCR) are unaffected.
+mb = float(os.environ.get("MONEY_BASE", "1.0"))
+val = lambda v: float(pyo.value(v))
+phys = lambda x: x / f1
+cost = None
+if have_sol:
+    try:
+        cost = val(m.eTotalSCost) * mb
+    except Exception:
+        cost = None
+summary = {"case": CASE, "variant": VARIANT or "A3", "mode": MODE, "firm": FIRM, "horizon": bc.HORIZON, "factor1": f1,
+           "money_base": mb, "hnscost": bc.HNSCOST, "termination": tc, "timelimit_s": TIMELIMIT, "mipgap_target": MIPGAP,
+           "currency": bc.CURRENCY, "eTotalSCost_SEK": cost}   # eTotalSCost_SEK holds the model currency (see 'currency')
+for k, attr in (("bound_lower", "lower_bound"), ("bound_upper", "upper_bound")):
+    try:
+        summary[k] = float(getattr(res.problem, attr)) * mb
+    except Exception:
+        summary[k] = None
+if cost is not None:
+    # peak (demand) charge component, for comparing big-M vs CVaR peak formulations
+    try:
+        summary["peak_cost_SEK"] = sum(val(m.vTotalElePeakCost[i]) for i in m.vTotalElePeakCost) * mb
+    except Exception:
+        summary["peak_cost_SEK"] = None
+    summary["HNS_total_kgH2"] = phys(sum(val(m.vHNS[i]) for i in m.vHNS))
+    # How the hydrogen demand is actually met: served on-site vs bought from the import
+    # backstop. With elastic (price-responsive) demand, unmet demand is FOREGONE (not HNS),
+    # so a near-zero HNS can still hide a hydrogen business that produced nothing -- these
+    # two totals make that visible.
+    summary["H2_demand_served_kgH2"] = phys(sum(val(m.vHydDemand[i]) for i in m.vHydDemand))
+    summary["H2_import_buy_kgH2"] = phys(sum(val(m.vHydBuy[i]) for i in m.vHydBuy))
+    summary["ele_build"] = {u: val(m.vEleGenInvest[u]) for u in m.egc}
+    summary["hyd_build"] = {u: val(m.vHydGenInvest[u]) for u in m.hgc}
+    summary["comp_build"] = {u: val(m.vHydCompInvest[u]) for u in m.hgcompc}
+    # standalone Technology="Compressor" units (PRESSURE_NODES) are sized by vHydCompBuild over hcc,
+    # not the tank-welded vHydCompInvest above; include them so the compressor size is reported.
+    if hasattr(m, "vHydCompBuild"):
+        summary["comp_build"].update({u: val(m.vHydCompBuild[u]) for u in m.hcc})
+    # Invested grid-connection capacity (MW). Present only when the connection-investment
+    # feature is active (pParEleConnInvestCost > 0); phys() -> kW, /1000 -> MW.
+    try:
+        summary["ele_conn_cap_MW"] = phys(val(m.vEleConnCap)) / 1000.0 if hasattr(m, "vEleConnCap") else None
+    except Exception:
+        summary["ele_conn_cap_MW"] = None
+
+    # FCR provision split: sum each product's bid over all load levels, per asset
+    # (the last index is the asset). Shares are scale-invariant, so this captures
+    # the headline battery-vs-electrolyser split without the model's result tables.
+    fcr_vars = {
+        "vEleFreqContReserveDisUpwardBid": "FCR-D up",
+        "vEleFreqContReserveDisDownwardBid": "FCR-D down",
+        "vEleFreqContReserveNorBid": "FCR-N",
+    }
+    fcr = {}
+    for vname, label in fcr_vars.items():
+        comp = getattr(m, vname, None)
+        if comp is None:
+            continue
+        by_asset = {}
+        for idx in comp:
+            asset = idx[-1]
+            by_asset[asset] = by_asset.get(asset, 0.0) + val(comp[idx])
+        fcr[label] = by_asset
+    summary["fcr_sum_by_asset"] = fcr
+
+    # Storage dual-leg FCR simultaneity: hours where a storage unit bids FCR-up from BOTH the
+    # charge and the discharge leg at once (the simultaneous charge+discharge reserve loophole).
+    # With leg-exclusive FCR (STOR_FCR_LEG=1) this should drop toward zero.
+    try:
+        dual = {}
+        for egs in m.egs:
+            cnt = 0
+            for (pp, ss, nn) in m.psn:
+                up_cha = val(m.vEleFreqContReserveDisUpCha[pp, ss, nn, egs]) + val(m.vEleFreqContReserveNorUpCha[pp, ss, nn, egs])
+                up_dis = val(m.vEleFreqContReserveDisUpDis[pp, ss, nn, egs]) + val(m.vEleFreqContReserveNorUpDis[pp, ss, nn, egs])
+                if up_cha > 1e-3 and up_dis > 1e-3:
+                    cnt += 1
+            dual[egs] = cnt
+        summary["fcr_dual_leg_hours"] = dual
+    except Exception:
+        pass
+
+# Conditioning probe (opt-in -- the measurement backbone for the scaling work). CONDITIONING=1
+# records the constraint-matrix and variable-bound coefficient ranges (no solve, but iterates
+# every constraint, so it is slow at year scale -- run it deliberately). KAPPA=1 additionally
+# solves once with a simplex basis to read Gurobi's condition number (KappaExact); needs gurobipy.
+# A lower matrix oom / kappa after a rescale (e.g. MONEY_BASE) is the evidence the rescale helped.
+if os.environ.get("CONDITIONING") == "1" or os.environ.get("KAPPA") == "1":
+    spec_c = importlib.util.spec_from_file_location(
+        "conditioning", REPO / "analysis" / "conditioning.py")
+    cond = importlib.util.module_from_spec(spec_c); spec_c.loader.exec_module(cond)
+    summary["conditioning"] = {}
+    if os.environ.get("CONDITIONING") == "1":
+        print("conditioning: computing matrix + bound ranges ...", flush=True)
+        summary["conditioning"]["ranges"] = cond.matrix_and_bound_ranges(m)
+    if os.environ.get("KAPPA") == "1":
+        print("conditioning: simplex probe for KappaExact ...", flush=True)
+        summary["conditioning"]["kappa"] = cond.kappa_exact(m)
+
+out = work / f"summary_{CASE}.json"
+out.write_text(json.dumps(summary, indent=2))
+print("\n" + "=" * 60, flush=True)
+print(json.dumps(summary, indent=2), flush=True)
+print("=" * 60, flush=True)
+print(f"summary -> {out}", flush=True)
+
+# Optional full results output (all oT_* tables, incl. hourly dispatch) -> work/CASE/results.duckdb.
+# Opt-in (FULL_OUTPUT=1) because it is only needed for dispatch figures, not the matrix summary.
+if os.environ.get("FULL_OUTPUT") == "1" and have_sol:
+    from el1xr_opt.Modules.oM_OutputData_duckdb import save_to_duckdb
+    save_to_duckdb(str(work), CASE, m, m, date=NOW, solver="gurobi")
+    print(f"full output -> {wc / 'results.duckdb'}", flush=True)
+
+# Slim hourly dispatch archive (SLIM_OUTPUT=1): a curated set of the time-resolved series, in
+# physical units (/factor1), written as one tidy parquet per case. Small (a few MB), columnar and
+# queryable -- the reusable record so we never re-solve just to recover a dispatch detail. Written
+# via DuckDB so it needs no pyarrow. Money-base independent (only physical quantities).
+if os.environ.get("SLIM_OUTPUT") == "1" and have_sol:
+    import pandas as pd
+    _SLIM_VARS = ["vEleTotalCharge", "vEleTotalOutput", "vHydTotalOutput", "vHydInventory",
+                  "vEleFreqContReserveDisUpwardBid", "vEleFreqContReserveDisDownwardBid",
+                  "vEleFreqContReserveNorBid", "vEleBuy", "vEleSell", "vHydDemand", "vHydBuy"]
+    _recs = []
+    for _vn in _SLIM_VARS:
+        comp = getattr(m, _vn, None)
+        if comp is None:
+            continue
+        for idx in comp:
+            try:
+                v = val(comp[idx])
+            except Exception:
+                continue
+            _recs.append((idx[0], idx[1], idx[2], _vn, idx[-1] if len(idx) > 3 else "", v / f1))
+    sdf = pd.DataFrame(_recs, columns=["period", "scenario", "loadlevel", "variable", "unit", "value"])
+    spq = work / f"slim_dispatch_{CASE}.parquet"
+    try:
+        import duckdb
+        con = duckdb.connect()
+        con.register("slim", sdf)
+        con.execute(f"COPY slim TO '{spq}' (FORMAT PARQUET)")
+        con.close()
+    except Exception:
+        sdf.to_parquet(spq, index=False)   # fallback if a parquet engine is present
+    print(f"slim output -> {spq} ({len(sdf)} rows, {sdf['variable'].nunique()} series)", flush=True)

--- a/data/H2VPPFCR/sweeps/b1_pemmenu_year.json
+++ b/data/H2VPPFCR/sweeps/b1_pemmenu_year.json
@@ -1,0 +1,35 @@
+{
+  "name": "b1_pemmenu",
+  "variant": "A3",
+  "horizon": "year",
+  "_note": "B1 check (review 2026-07-26): PEM is built at its 9 MW candidate ceiling (PEM_N=6) in every case where it is offered, so the paper's 'the menu is wide enough that the total fleet is interior' does not hold for the PEM sub-menu. Widen the PEM menu and re-solve A3. pem06 is the self-check (= A3, must return -36,859,605 SEK). Cells run in order, so pem14 can be dropped once pem10 answers the question.",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "7200",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12"
+  },
+  "cells": [
+    {"tag": "pem06", "env": {"PEM_N": "6"}},
+    {"tag": "pem10", "env": {"PEM_N": "10"}},
+    {"tag": "pem14", "env": {"PEM_N": "14"}}
+  ]
+}

--- a/data/H2VPPFCR/sweeps/fcr_erosion_year.json
+++ b/data/H2VPPFCR/sweeps/fcr_erosion_year.json
@@ -1,0 +1,30 @@
+{
+  "name": "fcr",
+  "variant": "A3",
+  "horizon": "year",
+  "base_env": {
+    "LP": "1",
+    "TRANSPORT_NET": "1",
+    "MONEY_BASE": "1000",
+    "ELE_3STATE_TIGHT": "1",
+    "ELE_RAMP_CAP": "1",
+    "PEAK_THRESHOLD_LP": "1",
+    "ELE_OPER_SYMBREAK": "1",
+    "RESERVE_DELIVERY": "1",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "TIMELIMIT": "7200"
+  },
+  "cells": [
+    {"tag": "s10",  "env": {"FCR_PRICE_SCALE": "1.0"}},
+    {"tag": "s075", "env": {"FCR_PRICE_SCALE": "0.75"}},
+    {"tag": "s05",  "env": {"FCR_PRICE_SCALE": "0.5"}},
+    {"tag": "s025", "env": {"FCR_PRICE_SCALE": "0.25"}},
+    {"tag": "s00",  "env": {"FCR_PRICE_SCALE": "0.0"}}
+  ]
+}

--- a/data/H2VPPFCR/sweeps/heatmap_month.json
+++ b/data/H2VPPFCR/sweeps/heatmap_month.json
@@ -1,0 +1,201 @@
+{
+  "name": "hm",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "1",
+    "TRANSPORT_NET": "1",
+    "MONEY_BASE": "1000",
+    "ELE_3STATE_TIGHT": "1",
+    "ELE_RAMP_CAP": "1",
+    "PEAK_THRESHOLD_LP": "1",
+    "ELE_OPER_SYMBREAK": "1",
+    "RESERVE_DELIVERY": "1",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "PRESOLVE": "2",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "TIMELIMIT": "7200"
+  },
+  "cells": [
+    {
+      "tag": "d0p06",
+      "env": {
+        "DEG_SCALE": "0",
+        "H2_PRICE_SCALE": "0.6"
+      }
+    },
+    {
+      "tag": "d0p08",
+      "env": {
+        "DEG_SCALE": "0",
+        "H2_PRICE_SCALE": "0.8"
+      }
+    },
+    {
+      "tag": "d0p10",
+      "env": {
+        "DEG_SCALE": "0",
+        "H2_PRICE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "d0p12",
+      "env": {
+        "DEG_SCALE": "0",
+        "H2_PRICE_SCALE": "1.2"
+      }
+    },
+    {
+      "tag": "d0p14",
+      "env": {
+        "DEG_SCALE": "0",
+        "H2_PRICE_SCALE": "1.4"
+      }
+    },
+    {
+      "tag": "d2p06",
+      "env": {
+        "DEG_SCALE": "2",
+        "H2_PRICE_SCALE": "0.6"
+      }
+    },
+    {
+      "tag": "d2p08",
+      "env": {
+        "DEG_SCALE": "2",
+        "H2_PRICE_SCALE": "0.8"
+      }
+    },
+    {
+      "tag": "d2p10",
+      "env": {
+        "DEG_SCALE": "2",
+        "H2_PRICE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "d2p12",
+      "env": {
+        "DEG_SCALE": "2",
+        "H2_PRICE_SCALE": "1.2"
+      }
+    },
+    {
+      "tag": "d2p14",
+      "env": {
+        "DEG_SCALE": "2",
+        "H2_PRICE_SCALE": "1.4"
+      }
+    },
+    {
+      "tag": "d5p06",
+      "env": {
+        "DEG_SCALE": "5",
+        "H2_PRICE_SCALE": "0.6"
+      }
+    },
+    {
+      "tag": "d5p08",
+      "env": {
+        "DEG_SCALE": "5",
+        "H2_PRICE_SCALE": "0.8"
+      }
+    },
+    {
+      "tag": "d5p10",
+      "env": {
+        "DEG_SCALE": "5",
+        "H2_PRICE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "d5p12",
+      "env": {
+        "DEG_SCALE": "5",
+        "H2_PRICE_SCALE": "1.2"
+      }
+    },
+    {
+      "tag": "d5p14",
+      "env": {
+        "DEG_SCALE": "5",
+        "H2_PRICE_SCALE": "1.4"
+      }
+    },
+    {
+      "tag": "d8p06",
+      "env": {
+        "DEG_SCALE": "8",
+        "H2_PRICE_SCALE": "0.6"
+      }
+    },
+    {
+      "tag": "d8p08",
+      "env": {
+        "DEG_SCALE": "8",
+        "H2_PRICE_SCALE": "0.8"
+      }
+    },
+    {
+      "tag": "d8p10",
+      "env": {
+        "DEG_SCALE": "8",
+        "H2_PRICE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "d8p12",
+      "env": {
+        "DEG_SCALE": "8",
+        "H2_PRICE_SCALE": "1.2"
+      }
+    },
+    {
+      "tag": "d8p14",
+      "env": {
+        "DEG_SCALE": "8",
+        "H2_PRICE_SCALE": "1.4"
+      }
+    },
+    {
+      "tag": "d12p06",
+      "env": {
+        "DEG_SCALE": "12",
+        "H2_PRICE_SCALE": "0.6"
+      }
+    },
+    {
+      "tag": "d12p08",
+      "env": {
+        "DEG_SCALE": "12",
+        "H2_PRICE_SCALE": "0.8"
+      }
+    },
+    {
+      "tag": "d12p10",
+      "env": {
+        "DEG_SCALE": "12",
+        "H2_PRICE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "d12p12",
+      "env": {
+        "DEG_SCALE": "12",
+        "H2_PRICE_SCALE": "1.2"
+      }
+    },
+    {
+      "tag": "d12p14",
+      "env": {
+        "DEG_SCALE": "12",
+        "H2_PRICE_SCALE": "1.4"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m1_foresight_month.json
+++ b/data/H2VPPFCR/sweeps/m1_foresight_month.json
@@ -1,0 +1,48 @@
+{
+  "name": "m1_foresight",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "7200",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m3b_h2price/sum_h2p100.json"
+  },
+  "cells": [
+    {
+      "tag": "foresight",
+      "env": {}
+    },
+    {
+      "tag": "committed_flat",
+      "env": {
+        "COMMIT_AHEAD": "1"
+      }
+    },
+    {
+      "tag": "committed_diurnal",
+      "env": {
+        "COMMIT_AHEAD": "diurnal"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m2_gates_year.json
+++ b/data/H2VPPFCR/sweeps/m2_gates_year.json
@@ -1,0 +1,43 @@
+{
+  "name": "m2_gates",
+  "variant": "A3",
+  "horizon": "year",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "7200",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12"
+  },
+  "cells": [
+    {
+      "tag": "baseline",
+      "env": {}
+    },
+    {
+      "tag": "gatesoff",
+      "env": {
+        "ELE_FCRD_RAMPGATE": "0",
+        "FCR_ENDURANCE_MIN_D": "0",
+        "FCR_ENDURANCE_MIN_N": "0"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m3b_h2price_year.json
+++ b/data/H2VPPFCR/sweeps/m3b_h2price_year.json
@@ -1,0 +1,39 @@
+{
+  "name": "m3b_h2price",
+  "variant": "A3",
+  "horizon": "year",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "7200",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1"
+  },
+  "cells": [
+    {"tag": "h2p100", "env": {"H2_PRICE_SCALE": "1.0"}},
+    {"tag": "h2p070", "env": {"H2_PRICE_SCALE": "0.7"}},
+    {"tag": "h2p050", "env": {"H2_PRICE_SCALE": "0.5"}},
+    {"tag": "h2p040", "env": {"H2_PRICE_SCALE": "0.4"}},
+    {"tag": "h2p030", "env": {"H2_PRICE_SCALE": "0.3"}},
+    {"tag": "h2p020", "env": {"H2_PRICE_SCALE": "0.2"}},
+    {"tag": "h2p010", "env": {"H2_PRICE_SCALE": "0.1"}},
+    {"tag": "h2p005", "env": {"H2_PRICE_SCALE": "0.05"}},
+    {"tag": "h2p000", "env": {"H2_PRICE_SCALE": "0.0"}}
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m4_windcapex_year.json
+++ b/data/H2VPPFCR/sweeps/m4_windcapex_year.json
@@ -1,0 +1,33 @@
+{
+  "name": "m4_windcapex",
+  "variant": "A3",
+  "horizon": "year",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "7200",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12"
+  },
+  "cells": [
+    {"tag": "wcap_low", "env": {"WIND_CAPEX_EUR_KW": "860"}},
+    {"tag": "wcap_high", "env": {"WIND_CAPEX_EUR_KW": "1434"}}
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A2_full.json
+++ b/data/H2VPPFCR/sweeps/m7a_A2_full.json
@@ -1,0 +1,68 @@
+{
+  "name": "m7a_A2_full",
+  "variant": "A2",
+  "horizon": "month",
+  "base_env": {
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "4",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A2.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {
+        "LP": "1",
+        "TIMELIMIT": "3600"
+      }
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "7200"
+      }
+    },
+    {
+      "tag": "milp_c100",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "3600",
+        "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_A2_full/sum_lp.json",
+        "FIX_RESERVE_LEVEL": "class",
+        "FIX_RESERVE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "milp_c050",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "5400",
+        "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_A2_full/sum_lp.json",
+        "FIX_RESERVE_LEVEL": "class",
+        "FIX_RESERVE_SCALE": "0.5"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A2_milp12.json
+++ b/data/H2VPPFCR/sweeps/m7a_A2_milp12.json
@@ -1,0 +1,38 @@
+{
+  "name": "m7a_A2_milp12",
+  "variant": "A2",
+  "horizon": "month",
+  "base_env": {
+    "LP": "0",
+    "ELE_3STATE_TIGHT": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "10800",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A2.json"
+  },
+  "cells": [
+    {
+      "tag": "milp",
+      "env": {}
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A2_month.json
+++ b/data/H2VPPFCR/sweeps/m7a_A2_month.json
@@ -1,0 +1,44 @@
+{
+  "name": "m7a_A2",
+  "variant": "A2",
+  "horizon": "month",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "10800",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A2.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {}
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A3_class.json
+++ b/data/H2VPPFCR/sweeps/m7a_A3_class.json
@@ -1,0 +1,62 @@
+{
+  "name": "m7a_A3_class",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "0",
+    "ELE_3STATE_TIGHT": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "3600",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A3.json",
+    "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_A3/sum_lp.json",
+    "FIX_RESERVE_TOL": "0.01",
+    "FIX_RESERVE_LEVEL": "class"
+  },
+  "cells": [
+    {
+      "tag": "lp_class_chk",
+      "env": {
+        "LP": "1",
+        "FIX_RESERVE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "milp_c100",
+      "env": {
+        "FIX_RESERVE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "milp_c070",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.7"
+      }
+    },
+    {
+      "tag": "milp_c050",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.5"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A3_diag.json
+++ b/data/H2VPPFCR/sweeps/m7a_A3_diag.json
@@ -1,0 +1,49 @@
+{
+  "name": "m7a_A3_diag",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "0",
+    "ELE_3STATE_TIGHT": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "3600",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A3.json",
+    "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_A3/sum_lp.json",
+    "FIX_RESERVE_TOL": "0.01"
+  },
+  "cells": [
+    {
+      "tag": "lp_pin_check",
+      "env": {
+        "LP": "1",
+        "FIX_RESERVE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "milp_s010",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.1"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A3_fracsweep.json
+++ b/data/H2VPPFCR/sweeps/m7a_A3_fracsweep.json
@@ -1,0 +1,66 @@
+{
+  "name": "m7a_A3_fracsweep",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "0",
+    "ELE_3STATE_TIGHT": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "3600",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A3.json",
+    "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_A3/sum_lp.json",
+    "FIX_RESERVE_TOL": "0.01"
+  },
+  "cells": [
+    {
+      "tag": "s090",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.9"
+      }
+    },
+    {
+      "tag": "s080",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.8"
+      }
+    },
+    {
+      "tag": "s070",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.7"
+      }
+    },
+    {
+      "tag": "s060",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.6"
+      }
+    },
+    {
+      "tag": "s050",
+      "env": {
+        "FIX_RESERVE_SCALE": "0.5"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A3_hard.json
+++ b/data/H2VPPFCR/sweeps/m7a_A3_hard.json
@@ -1,0 +1,40 @@
+{
+  "name": "m7a_A3_hard",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "0",
+    "ELE_3STATE_TIGHT": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "7200",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A3.json",
+    "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_A3/sum_lp.json",
+    "FIX_RESERVE_TOL": "0.01"
+  },
+  "cells": [
+    {
+      "tag": "milp_fixsplit",
+      "env": {}
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_A3_month.json
+++ b/data/H2VPPFCR/sweeps/m7a_A3_month.json
@@ -1,0 +1,44 @@
+{
+  "name": "m7a_A3",
+  "variant": "A3",
+  "horizon": "month",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "10800",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/A3.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {}
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_B1_full.json
+++ b/data/H2VPPFCR/sweeps/m7a_B1_full.json
@@ -1,0 +1,68 @@
+{
+  "name": "m7a_B1_full",
+  "variant": "B1",
+  "horizon": "month",
+  "base_env": {
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "4",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/B1.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {
+        "LP": "1",
+        "TIMELIMIT": "3600"
+      }
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "7200"
+      }
+    },
+    {
+      "tag": "milp_c100",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "3600",
+        "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_B1_full/sum_lp.json",
+        "FIX_RESERVE_LEVEL": "class",
+        "FIX_RESERVE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "milp_c050",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "5400",
+        "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_B1_full/sum_lp.json",
+        "FIX_RESERVE_LEVEL": "class",
+        "FIX_RESERVE_SCALE": "0.5"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_B1_milp12.json
+++ b/data/H2VPPFCR/sweeps/m7a_B1_milp12.json
@@ -1,0 +1,38 @@
+{
+  "name": "m7a_B1_milp12",
+  "variant": "B1",
+  "horizon": "month",
+  "base_env": {
+    "LP": "0",
+    "ELE_3STATE_TIGHT": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "10800",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/B1.json"
+  },
+  "cells": [
+    {
+      "tag": "milp",
+      "env": {}
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_B1_month.json
+++ b/data/H2VPPFCR/sweeps/m7a_B1_month.json
@@ -1,0 +1,44 @@
+{
+  "name": "m7a_B1",
+  "variant": "B1",
+  "horizon": "month",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "10800",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/B1.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {}
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_B2_full.json
+++ b/data/H2VPPFCR/sweeps/m7a_B2_full.json
@@ -1,0 +1,68 @@
+{
+  "name": "m7a_B2_full",
+  "variant": "B2",
+  "horizon": "month",
+  "base_env": {
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "4",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/B2.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {
+        "LP": "1",
+        "TIMELIMIT": "3600"
+      }
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "7200"
+      }
+    },
+    {
+      "tag": "milp_c100",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "3600",
+        "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_B2_full/sum_lp.json",
+        "FIX_RESERVE_LEVEL": "class",
+        "FIX_RESERVE_SCALE": "1.0"
+      }
+    },
+    {
+      "tag": "milp_c050",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1",
+        "TIMELIMIT": "5400",
+        "FIX_RESERVE_SPLIT": "D:/h2vpp_run/results/h2vpp_fcr/sweep_m7a_B2_full/sum_lp.json",
+        "FIX_RESERVE_LEVEL": "class",
+        "FIX_RESERVE_SCALE": "0.5"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/m7a_B2_month.json
+++ b/data/H2VPPFCR/sweeps/m7a_B2_month.json
@@ -1,0 +1,44 @@
+{
+  "name": "m7a_B2",
+  "variant": "B2",
+  "horizon": "month",
+  "base_env": {
+    "LP": "1",
+    "PRESSURE_NODES": "1",
+    "ENHANCED_PROFILES": "1",
+    "MONEY_BASE": "1000",
+    "PEAK_THRESHOLD_LP": "1",
+    "AEL_N": "6",
+    "PEM_N": "6",
+    "COMPRESSOR_NAMEPLATE_KG": "1000",
+    "WIND_MAX_POWER_KW": "60000",
+    "LINE_TTC_KW": "60000",
+    "ELE_BUY_CAP_KW": "60000",
+    "TIMELIMIT": "10800",
+    "ELE_FCRD_RAMPGATE": "1",
+    "AEL_FCRD_RAMP_PER_S": "0.02",
+    "PEM_FCRD_RAMP_PER_S": "0.10",
+    "METHOD": "2",
+    "CROSSOVER": "0",
+    "SCALEFLAG": "2",
+    "NUMERICFOCUS": "3",
+    "BARHOMOGENEOUS": "1",
+    "CONCURRENT_FALLBACK": "1",
+    "THREADS": "12",
+    "MIPGAP": "0.01",
+    "FIX_INVEST": "D:/h2vpp_run/results/h2vpp_fcr/m7a_fix/B2.json"
+  },
+  "cells": [
+    {
+      "tag": "lp",
+      "env": {}
+    },
+    {
+      "tag": "milp",
+      "env": {
+        "LP": "0",
+        "ELE_3STATE_TIGHT": "1"
+      }
+    }
+  ]
+}

--- a/data/H2VPPFCR/sweeps/week_fcr_check.json
+++ b/data/H2VPPFCR/sweeps/week_fcr_check.json
@@ -1,0 +1,21 @@
+{
+  "name": "week_fcr_check",
+  "variant": "A3",
+  "horizon": "week",
+  "base_env": {
+    "LP": "1",
+    "TRANSPORT_NET": "1",
+    "MONEY_BASE": "1000",
+    "ELE_3STATE_TIGHT": "1",
+    "ELE_RAMP_CAP": "1",
+    "PEAK_THRESHOLD_LP": "1",
+    "ELE_OPER_SYMBREAK": "1",
+    "RESERVE_DELIVERY": "1",
+    "SOLVER": "highs",
+    "TIMELIMIT": "1800"
+  },
+  "cells": [
+    {"tag": "s10", "env": {"FCR_PRICE_SCALE": "1.0"}},
+    {"tag": "s05", "env": {"FCR_PRICE_SCALE": "0.5"}}
+  ]
+}


### PR DESCRIPTION
The README for `data/H2VPPFCR/` says every number in the paper regenerates from that
directory. Two things stop it.

**`run_year.py` was never copied here.** It builds a case, solves it and writes the
summary, and all three campaign runners shell out to it. They looked for it at
`<repo>/experiments/h2vpp_fcr/run_year.py`, which is its path in the paper's companion
repository and nowhere in this one, so the headline campaign could not start. They now
call the copy next to them.

**Six results are sweeps, and their specs were missing.** The deliverability
decomposition behind contribution 1, the wind-capex case S10, the hydrogen-price and
FCR-erosion figures, the widened electrolyser menu S11, and the degradation-by-price
heatmap are all multi-cell sweeps. This adds `run_sweep.py` and all 21 specs under
`sweeps/`, including the month-horizon foresight and integer-commitment checks the paper
reports in the text.

### Keeping one copy, not two

`run_year.py` and `run_sweep.py` are byte-identical to the companion repository's copies.
The two repositories keep `el1xr_opt` in different places — `model/src` there, `src/` here
— so rather than let the copies diverge, both now try each location and let an installed
package win over either. The companion repo resolves `model/src` first, so its behaviour
is unchanged.

### README

Adds a table mapping each sweep spec to the result it produces, a note on where results
land and how to redirect them with `H2VPP_OUTBASE`, and a note that the conditioning
probe loads a file from the companion repository and is not needed to reproduce anything
here.

### Checking

Every file parses and every module-scope name resolves. No model code is touched — this
is the dataset bundle only.