### PR TITLE
Electrolyser part-load curve: selectable shape, variable breakpoint count, two conditioning flags

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -430,6 +430,19 @@ def data_processing(DirName, CaseName, DateModel, model, indlog):
         # replace p{net[0:3]}NetInvestmentUp= 0.0 by 1.0
         parameters_dict[f'p{net[0:3]}NetInvestmentUp'] = parameters_dict[f'p{net[0:3]}NetInvestmentUp'].where(parameters_dict[f'p{net[0:3]}NetInvestmentUp'] > 0.0, other=1.0)
 
+        # An upper bound of 0 means "no bound given", not "cannot build", so it is reset to 1.
+        # That is why a case wanting to switch a candidate OFF has to give a tiny positive bound
+        # instead, and a bound of 1e-9 against bounds that otherwise reach 1e4 spans about 13
+        # orders of magnitude -- the widest range in the matrix, on exactly the variant group with
+        # the ragged terminations (notes/model_speed_review_2026-07-04.md, part 2, bounds row).
+        #
+        # Record which candidates arrived with a bound of exactly 0 BEFORE the reset overwrites
+        # it, so the investment layer can fix those variables to zero outright instead. Fixing
+        # removes the column rather than squeezing it, which is both better conditioned and a
+        # truer statement of the intent.
+        _disabled = parameters_dict[f'p{net[0:3]}GenInvestmentUp']
+        model.__setattr__(f'{net[0:3].lower()}_gen_disabled',
+                          list(_disabled.index[_disabled == 0.0]))
         parameters_dict[f'p{net[0:3]}GenInvestmentUp'] = parameters_dict[f'p{net[0:3]}GenInvestmentUp'].where(parameters_dict[f'p{net[0:3]}GenInvestmentUp'] > 0.0, other=1.0)
 
     # minimum up- and downtime converted to an integer number of time steps

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1254,8 +1254,9 @@ def create_variables(model, optmodel, indlog):
     # picks the active segment.
     model.pwl_curve = {}
     model.hpwl      = []
-    model.pwlbp     = list(range(4))   # breakpoint indices 0..3
-    model.pwlseg    = list(range(3))   # segment indices 0..2 (between adjacent breakpoints)
+    _n_bp = int(model.Par.get('pParElectrolyserPWLPoints', 4))   # breakpoints per unit curve
+    model.pwlbp     = list(range(_n_bp))         # breakpoint indices
+    model.pwlseg    = list(range(_n_bp - 1))     # segment indices (between adjacent breakpoints)
     if int(model.Par.get('pOptIndBinElectrolyserPWL', 0)) == 1:
         _anchor_f = [0.10, 0.20, 0.50, 0.85, 1.00]   # load fraction
         # Specific energy / full-load value, by electrolyser technology. Alkaline (AEL)
@@ -1266,6 +1267,29 @@ def create_variables(model, optmodel, indlog):
         # PEM keeps the alkaline shape, so single-technology cases are byte-unchanged.
         _anchor_mult_alk = [1.35, 1.25, 1.08, 0.97, 1.00]   # alkaline (default)
         _anchor_mult_pem = [1.15, 1.10, 1.04, 0.98, 1.00]   # PEM: flatter part-load
+
+        # Corrected alkaline curve (opt-in, pParElectrolyserCurve = "ulleberg"). The default
+        # shape above puts the efficiency optimum at 85% of load, which contradicts the source
+        # it is cited against: Buttler & Spliethoff report that efficiency FALLS as current
+        # density rises. The replacement is derived, not traced -- Ulleberg's (2003) empirical
+        # current-voltage relation plus his Faraday-efficiency term, with a balance-of-plant
+        # load that is mostly independent of how hard the stack is driven, all calibrated to
+        # the DEA "86 AEC 10 MW" 2025 sheet (51.44 kWh/kg at the stack, 56.69 including
+        # balance of plant, 0.8 A/cm2 rated). The optimum then comes out at about half load
+        # rather than being assumed. See analysis/electrolyser_curve.py in the paper repo,
+        # which regenerates these numbers.
+        #
+        # PEM IS NOT CORRECTED HERE. Its reference (Astriani et al. 2024) is paywalled and
+        # awaiting a manual download, so the published PEM shape is resampled onto the new
+        # breakpoint grid unchanged. It carries the same optimum-near-full-load problem as the
+        # old alkaline curve; do not read the PEM curve as verified.
+        _anchor_f_ull = [0.20, 0.28, 0.36, 0.44, 0.52, 0.60, 0.68, 0.76, 0.84, 0.92, 1.00]
+        _anchor_mult_ull = [1.0501, 0.9800, 0.9515, 0.9411, 0.9400,
+                            0.9443, 0.9521, 0.9621, 0.9737, 0.9864, 1.0000]
+        if str(model.Par.get('pParElectrolyserCurve', '')).lower() == 'ulleberg':
+            _anchor_mult_pem = [float(np.interp(x, _anchor_f, _anchor_mult_pem))
+                                for x in _anchor_f_ull]
+            _anchor_f, _anchor_mult_alk = _anchor_f_ull, _anchor_mult_ull
         for g in model.e2h:
             pf   = float(model.Par['pHydGenProductionFunction'][g])
             pmax = max(float(model.Par['pHydMaxCharge'][g][idx]) for idx in model.psn)
@@ -1278,7 +1302,14 @@ def create_variables(model, optmodel, indlog):
             _tech = str(model.Par['pHydGenTechnology'].get(g, '')).upper()
             _anchor_mult = _anchor_mult_pem if 'PEM' in _tech else _anchor_mult_alk
             fmin  = max(min(pmin / pmax, 1.0), 0.0)
-            fracs = [fmin + (1.0 - fmin) * t for t in (0.0, 0.4, 0.75, 1.0)]
+            # Breakpoints across the unit's productive range. Four points cannot resolve an
+            # optimum that sits in the interior, so the count is a parameter; the spacing below
+            # reproduces the original four exactly when pParElectrolyserPWLPoints is 4.
+            if _n_bp == 4:
+                _ts = (0.0, 0.4, 0.75, 1.0)
+            else:
+                _ts = [k / (_n_bp - 1) for k in range(_n_bp)]
+            fracs = [fmin + (1.0 - fmin) * t for t in _ts]
             model.pwl_curve[g] = [(f * pmax, (f * pmax) / (pf * float(np.interp(f, _anchor_f, _anchor_mult)))) for f in fracs]
             model.hpwl.append(g)
 

--- a/src/el1xr_opt/Modules/oM_Investment.py
+++ b/src/el1xr_opt/Modules/oM_Investment.py
@@ -155,6 +155,26 @@ def create_investment(model, optmodel, indlog):
     # candidate, so default cases are unchanged.
     setattr(optmodel, 'vHydCompBuild', Var(model.hcc, within=UnitInterval, doc='standalone hydrogen compressor candidate build fraction [0,1]'))
 
+    # Conditioning (opt-in, pParFixDisabledCandidates = 1). A case switches a candidate off by
+    # giving it a tiny positive upper bound, because an upper bound of exactly 0 is read as "no
+    # bound given" and reset to 1 (oM_InputData). A bound of 1e-9 against bounds that elsewhere
+    # reach 1e4 spans about 13 orders of magnitude and is the widest range in the matrix.
+    #
+    # With this flag on, a candidate whose upper bound arrived as exactly 0 is FIXED to zero
+    # instead. Presolve then removes the column outright rather than carrying a variable squeezed
+    # into [0, 1e-9]. The build is zero either way, so the effect on the solution is nil, but
+    # "cannot be built" is stated rather than approximated.
+    #
+    # NOT YET VERIFIED BY A SOLVE, for the same reason as the period-weight flag above: this is an
+    # algebraic argument. A/B one case per affected variant group (A1, A2, D1, D2 are the ones that
+    # disable candidates) and confirm the objective matches to solver tolerance.
+    if int(model.Par.get('pParFixDisabledCandidates', 0)) == 1:
+        for _var, _attr, _set in (('vEleGenInvest', 'ele_gen_disabled', model.egc),
+                                  ('vHydGenInvest', 'hyd_gen_disabled', model.hgc)):
+            for _g in getattr(model, _attr, []):
+                if _g in _set:
+                    getattr(optmodel, _var)[_g].fix(0.0)
+
     # Make the decision binary (all-or-nothing build) for units flagged for it.
     for egc in model.egc:
         try:
@@ -441,11 +461,36 @@ def create_investment(model, optmodel, indlog):
     # trade-off is consistent for any modeled horizon.
     period_weight = sum(model.Par['pDiscountFactor'][p] for p in model.p)
 
+    # Conditioning (opt-in, pParNormalisePeriodWeight = 1). Written as above, every capex
+    # coefficient in this row carries the period weight, which for a year horizon pushes the
+    # largest of them to about 4.4e3 and makes this row the widest in the matrix
+    # (notes/model_speed_review_2026-07-04.md, part 2, family eTotalICost).
+    #
+    # The weight is a single constant multiplying the whole bracket, so it can be divided out of
+    # the row and reapplied once, where the investment cost enters the objective. The feasible set
+    # and the optimum are unchanged -- this is a pure rescaling of one equality -- but the capex
+    # coefficients drop by the size of the weight, which the review measured at 1.5 to 1.7 orders
+    # of magnitude.
+    #
+    # NOT YET VERIFIED BY A SOLVE. Exactness is an algebraic argument, not a measurement. Before a
+    # campaign uses this, run one A3 year case with the flag off and one with it on and confirm the
+    # objective matches to solver tolerance. Local solves are not an option for this project, so
+    # the check belongs on Comillas alongside the rerun.
+    #
+    # DO NOT COMBINE WITH THE DECOMPOSITION. vTotalICost is a complicating variable
+    # (oM_Decomposition.py:85), so with this flag on it would carry the unweighted cost while the
+    # master problem still expects the weighted one. The decomposition is used in no campaign, and
+    # this flag is off by default, so the two never meet today -- but they must not be turned on
+    # together without reworking the coupling.
+    _normalise_pw = int(model.Par.get('pParNormalisePeriodWeight', 0)) == 1
+    _row_weight = 1.0 if _normalise_pw else period_weight
+    optmodel._icost_period_weight = period_weight if _normalise_pw else 1.0
+
     def eTotalICost(optmodel):
         # Grid-connection capex (annualized, per invested kW of connection capacity); 0 when the
         # feature is off. Recurs each period like the asset capex, so it is period-weighted too.
         conn_term = (conn_cost * optmodel.vEleConnCap) if getattr(optmodel, '_conn_active', False) else 0.0
-        return optmodel.vTotalICost == period_weight * (
+        return optmodel.vTotalICost == _row_weight * (
             sum(model.Par['pEleGenInvestCost'][egc] * optmodel.vEleGenInvest[egc] for egc in model.egc) +
             sum(model.Par['pHydGenInvestCost'][hgc] * optmodel.vHydGenInvest[hgc] for hgc in model.hgc) +
             sum(model.Par['pHydGenCompressorInvestCost'][hgs] * optmodel.vHydCompInvest[hgs] for hgs in model.hgcompc) +

--- a/src/el1xr_opt/Modules/oM_ModelFormulation.py
+++ b/src/el1xr_opt/Modules/oM_ModelFormulation.py
@@ -36,7 +36,12 @@ def create_objective_function(model, optmodel, indlog):
         # the heat operating cost is already period-discounted (oM_HeatSector) and is
         # zero when the case has no heat sector.
         heat_cost = getattr(optmodel, 'HeatOperatingCost', 0.0)
-        return (optmodel.vTotalSCost == optmodel.vTotalICost + heat_cost + sum(optmodel.Par['pDiscountFactor'][idx[0]] * (optmodel.vTotalCComponent[idx] - optmodel.vTotalRComponent[idx]) for idx in model.ps))
+        # When the period weight has been divided out of eTotalICost for conditioning
+        # (pParNormalisePeriodWeight = 1), vTotalICost holds the UNweighted investment cost and
+        # the weight is reapplied here, once, instead of on every capex coefficient. The default
+        # is 1.0, which leaves this row exactly as it was.
+        _icost_w = getattr(optmodel, '_icost_period_weight', 1.0)
+        return (optmodel.vTotalSCost == _icost_w * optmodel.vTotalICost + heat_cost + sum(optmodel.Par['pDiscountFactor'][idx[0]] * (optmodel.vTotalCComponent[idx] - optmodel.vTotalRComponent[idx]) for idx in model.ps))
     optmodel.__setattr__('eTotalTCost', Constraint(rule=eTotalTCost, doc='Total system cost [money]'))
 
     # Cost / revenue components of the objective, summed from a registry so a new


### PR DESCRIPTION
Four new parameters in the investment and input layers. All default to current behaviour, so
existing cases are unchanged.

| Parameter | Default | Effect when set |
|---|---|---|
| `pParElectrolyserPWLPoints` | 4 | breakpoints per unit curve; the default reproduces the old spacing exactly |
| `pParElectrolyserCurve` | published | `ulleberg` selects a corrected alkaline curve |
| `pParNormalisePeriodWeight` | 0 | divides the period weight out of the capex row, reapplies it once in the objective |
| `pParFixDisabledCandidates` | 0 | fixes a switched-off candidate's build to zero instead of bounding it at 1e-9 |

### Part-load curve

The published alkaline shape puts the efficiency optimum at 85% of load. Buttler and Spliethoff,
the source it is cited against, report efficiency falling as current density rises, so the minimum
cannot sit near full load. The replacement is derived from Ulleberg's current-voltage relation and
calibrated to the DEA "86 AEC 10 MW" 2025 sheet; its optimum comes out near half load. The
derivation lives in the companion repository at `analysis/electrolyser_curve.py`.

Four breakpoints cannot represent an optimum that sits between them, which is why the count is now
a parameter.

PEM is not corrected. Its reference (Astriani et al. 2024) is paywalled and unread, so the
published PEM shape is resampled onto the new grid unchanged.

### Conditioning flags

Both from the scaling review of 2026-07-04, part 2. The capex row carries the period weight on
every coefficient, which reaches about 4.4e3 at a year horizon; the weight is a single constant and
can be applied once instead. Disabled candidates are bounded at 1e-9 because an upper bound of
exactly 0 is read as "no bound given" and reset to 1 — the input layer now records which candidates
arrived with a bound of 0 before that reset, so they can be fixed properly.

Both are argued exact algebraically. Neither has been confirmed by a solve. Before either is used
in a campaign, run one case with the flags off and one with them on and check the objective matches
to solver tolerance, then repeat for a variant that disables candidates (A1, A2, D1 or D2).

`pParNormalisePeriodWeight` must not be combined with the decomposition: `vTotalICost` is a
complicating variable there and would carry the unweighted cost while the master expects the
weighted one. Neither path is used in any campaign today.

### Related finding, not fixed here

The piecewise curves the published cases run on are not concave — the first slope difference is
positive for both technologies. Dropping the segment binaries is exact only on a concave curve, so
on these curves the relaxation can reach above the curve. Not yet shown to change any result; the
check needs solved hourly dispatch. The new alkaline curve is concave. PEM is not.