### PR TITLE
Allow geometric spacing of the electrolyser PWL breakpoints

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1318,11 +1318,28 @@ def create_variables(model, optmodel, indlog):
             # Breakpoints across the unit's productive range. Four points cannot resolve an
             # optimum that sits in the interior, so the count is a parameter; the spacing below
             # reproduces the original four exactly when pParElectrolyserPWLPoints is 4.
-            if _n_bp == 4:
-                _ts = (0.0, 0.4, 0.75, 1.0)
+            #
+            # Spacing matters more than count. The curve's error is not spread evenly: balance of
+            # plant divided by a falling output makes specific energy climb steeply at low load
+            # and flatten above it, so evenly spaced points waste resolution where the curve is
+            # nearly straight and miss it where it bends. Geometric spacing puts the points where
+            # the curvature is. Measured on the derived curves, seven geometric breakpoints beat
+            # eleven uniform ones on worst-case error while carrying 38% fewer columns:
+            #
+            #                       PEM max error        AEL max error
+            #     7 uniform             27.6%                1.7%
+            #    11 uniform             16.4%                0.8%
+            #     7 geometric            4.0%                0.5%
+            #    11 geometric            1.5%                0.2%
+            #
+            # Default stays uniform so existing cases are unchanged.
+            _spacing = str(model.Par.get('pParElectrolyserPWLSpacing', 'uniform')).lower()
+            if _spacing == 'geometric' and fmin > 0.0:
+                fracs = list(np.geomspace(fmin, 1.0, _n_bp))
+            elif _n_bp == 4:
+                fracs = [fmin + (1.0 - fmin) * t for t in (0.0, 0.4, 0.75, 1.0)]
             else:
-                _ts = [k / (_n_bp - 1) for k in range(_n_bp)]
-            fracs = [fmin + (1.0 - fmin) * t for t in _ts]
+                fracs = [fmin + (1.0 - fmin) * k / (_n_bp - 1) for k in range(_n_bp)]
             model.pwl_curve[g] = [(f * pmax, (f * pmax) / (pf * float(np.interp(f, _anchor_f, _anchor_mult)))) for f in fracs]
             model.hpwl.append(g)
 


### PR DESCRIPTION
Adds `pParElectrolyserPWLSpacing` (`uniform` | `geometric`), defaulting to `uniform`, so
existing cases are unchanged. Follows PR #160, which made the breakpoint count and the curve
shape parameters.

### Why

The approximation error is not spread evenly along the curve. Specific energy climbs steeply at
low load, where balance of plant is divided by a small output, and is nearly flat above the
optimum. Evenly spaced breakpoints therefore spend resolution where the curve is straight and
miss it where it bends.

Worst-case error of the piecewise approximation against the derived curves:

| | PEM | alkaline |
|---|---|---|
| 7 uniform | 27.6% | 1.7% |
| 11 uniform | 16.4% | 0.8% |
| 7 geometric | 4.0% | 0.5% |
| 11 geometric | 1.5% | 0.2% |

Seven geometric breakpoints beat eleven uniform ones on both technologies while carrying 38%
fewer columns.

PEM is the case that needs it: under uniform spacing almost all of its error sits below 15% of
load, where the curve turns sharply upward.

### Cost

At a year horizon with twelve electrolyser modules, the piecewise block adds roughly:

| breakpoints | columns | rows |
|---|---|---|
| 4 | 0.73 M | 0.84 M |
| 7 | 1.36 M | 1.15 M |
| 11 | 2.20 M | 1.57 M |

So the count is not free, which is the reason for preferring better-placed points over more of
them.

### Note

The geometric branch requires a positive minimum load; units with `fmin = 0` fall back to the
uniform spacing.

Unrelated to this change but worth recording: the PEM curve is not concave at seven or more
breakpoints, so dropping the segment binaries is not exact for it at any spacing. Alkaline is
concave at every count tested.