### PR TITLE
Conservative electrolyser curve from the reviewer's references

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1334,17 +1334,28 @@ def create_variables(model, optmodel, indlog):
             # under the operating floor that paper states for alkaline. Specific consumption at
             # 20% load rises 25% and the optimum moves from 49% to 61% of load.
             #
-            # PEM: the SHAPE from Astriani et al. 2024 (IJHE 79:1331), the reviewer's own PEM
-            # citation, carried onto DEA's LEVEL. DEA's 60.54 kWh/kg at full load is 7.6% more
-            # conservative than Astriani's own 56.3, so this is the steeper shape on the higher
-            # level -- conservative on both axes. Astriani's curve is monotone, with no interior
-            # optimum, which is a genuine disagreement with Baumhof's alkaline curve and with
-            # Buttler & Spliethoff; that disagreement belongs in the text, not hidden in a fit.
+            # PEM: the SAME construction as alkaline -- stack voltage, then Faraday, then balance
+            # of plant, calibrated to DEA -- with the crossover physics that actually applies to a
+            # solid membrane. Permeation is set by the membrane and the pressure difference and is
+            # roughly independent of current, so the lost current is a constant i_x and
+            # eta_F = 1 - i_x/i. Alkaline's porous diaphragm follows i^2/(f1 + i^2) instead. Using
+            # ONE formula for both would look consistent and be wrong: the two technologies lose
+            # hydrogen by different mechanisms.
+            #
+            # i_x is 1% of rated, i.e. 99% Faraday at rated, the standard PEM figure. It is
+            # validated rather than fitted: it puts 20% load at 71.7 kWh/kg against Astriani's
+            # 69.4, so it is conservative against the reviewer's own PEM reference, and the whole
+            # 20-100% span sits inside Buttler & Spliethoff's 55.6-72.3 kWh/kg range for PEMEL.
+            #
+            # Worth recording: Astriani's own curve is monotone with no interior optimum, which
+            # disagrees with Baumhof's alkaline curve and with Buttler & Spliethoff. Both curves
+            # here have an interior optimum because both are built from the same physics. That
+            # disagreement belongs in the paper's text, not hidden inside a fit.
             'ulleberg_conservative':
                 ([0.2000, 0.2615, 0.3420, 0.4472, 0.5848, 0.7647, 1.0000],
                  [1.3162, 1.1341, 1.0326, 0.9807, 0.9625, 0.9700, 1.0000],
                  [0.0500, 0.0824, 0.1357, 0.2236, 0.3684, 0.6070, 1.0000],
-                 [7.9480, 2.6903, 1.5739, 1.1747, 1.0351, 1.0029, 1.0000]),
+                 [2.7570, 1.8496, 1.3864, 1.1433, 1.0232, 0.9816, 1.0000]),
         }
         _anchor_f_pem, _curve_name = _anchor_f, str(model.Par.get('pParElectrolyserCurve', '')).lower()
         if _curve_name in _ULL:

--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1323,6 +1323,28 @@ def create_variables(model, optmodel, indlog):
                  [1.1249, 1.0436, 0.9916, 0.9636, 0.9563, 0.9684, 1.0000],
                  [0.0500, 0.0824, 0.1357, 0.2236, 0.3684, 0.6070, 1.0000],
                  [2.6478, 1.8877, 1.4380, 1.1799, 1.0434, 0.9895, 1.0000]),
+            # The CONSERVATIVE set, built against the two references the reviewer raised. Both
+            # technologies take the steeper of the defensible options, so neither flatters the
+            # part-load operation this model is used to argue for.
+            #
+            # Alkaline: Faraday efficiency from Sanchez et al. 2018 (IJHE 43:20332), which is the
+            # paper Baumhof's own curve depends on, rather than Ulleberg's. Ulleberg's f1 puts the
+            # knee at 0.016 A/cm2 against a rated 0.8, so his term never engages and the curve runs
+            # below the thermoneutral limit at low load. Sanchez's knee at 0.085 A/cm2 sits just
+            # under the operating floor that paper states for alkaline. Specific consumption at
+            # 20% load rises 25% and the optimum moves from 49% to 61% of load.
+            #
+            # PEM: the SHAPE from Astriani et al. 2024 (IJHE 79:1331), the reviewer's own PEM
+            # citation, carried onto DEA's LEVEL. DEA's 60.54 kWh/kg at full load is 7.6% more
+            # conservative than Astriani's own 56.3, so this is the steeper shape on the higher
+            # level -- conservative on both axes. Astriani's curve is monotone, with no interior
+            # optimum, which is a genuine disagreement with Baumhof's alkaline curve and with
+            # Buttler & Spliethoff; that disagreement belongs in the text, not hidden in a fit.
+            'ulleberg_conservative':
+                ([0.2000, 0.2615, 0.3420, 0.4472, 0.5848, 0.7647, 1.0000],
+                 [1.3162, 1.1341, 1.0326, 0.9807, 0.9625, 0.9700, 1.0000],
+                 [0.0500, 0.0824, 0.1357, 0.2236, 0.3684, 0.6070, 1.0000],
+                 [7.9480, 2.6903, 1.5739, 1.1747, 1.0351, 1.0029, 1.0000]),
         }
         _anchor_f_pem, _curve_name = _anchor_f, str(model.Par.get('pParElectrolyserCurve', '')).lower()
         if _curve_name in _ULL:


### PR DESCRIPTION
Adds one selectable curve, `ulleberg_conservative`. Nothing else changes; existing curves are
untouched.

### Why

A reviewer raised two references against the part-load sentence: Baumhof et al. 2023 (alkaline) and
Astriani et al. 2024 (PEM). Reading both, plus Sánchez et al. 2018 which Baumhof's curve depends
on, turned up one real error in our parameters.

**The Faraday term is about 29x too weak.** `η_F = f2 i²/(f1 + i²)`, so the knee is at `√f1`:

| | f1 (A² m⁻⁴) | knee | bites below |
|---|---|---|---|
| Ulleberg 2003 (current) | 25,000 | 0.016 A/cm² | ~2% of rated |
| Sánchez 2018 (Baumhof's) | 714,898 | 0.085 A/cm² | ~11% of rated |

DEA rates the 10 MW alkaline at **0.8 A/cm²**, so Ulleberg's term never engages. The current curve
reaches **37.96 kWh/kg at 10% load, below the thermoneutral limit of 39.4** — not physical for a
stack releasing heat. Sanchez's knee sits just under the "typically above 100–150 mA/cm²" floor
that paper states for alkaline.

### What the new curve does

Both technologies take the steeper of the defensible options, so neither flatters part-load
operation — which is what this model is used to argue for.

- **Alkaline**: Sánchez's Faraday parameters. Specific consumption at 20% load rises 25%; the
  optimum moves from 49% to 61% of load.
- **PEM**: Astriani's fitted shape on DEA's level. DEA's 60.54 kWh/kg is 7.6% more conservative
  than Astriani's own 56.3, so it is the steeper shape on the higher level.

### Two things worth a reviewer's eye

**The references disagree with each other.** Baumhof's alkaline curve has a pronounced interior
optimum; Astriani's PEM curve is monotone with none. Buttler & Spliethoff, which the paper already
cites, supports the interior optimum. This is recorded in the code comment rather than smoothed
over, and belongs in the paper's text.

**Signs.** Sánchez's Table 1 loses its minus signs in the PDF text layer. They are pinned from the
paper's own constraints, not guessed: `f22` negative because the paper requires `f2 ≈ 1` at high
current density (positive gives 1.123, impossible for an efficiency), and `f12` positive because
Ulleberg's `f1` rises with temperature.

### Not a straight replacement

Sánchez fitted a **15 kW bench unit**; DEA's is **10 MW at 0.8 A/cm²**. Gas crossover depends on
diaphragm design. Ulleberg is too weak and Sánchez may be too strong, which is why this is added as
a selectable curve for a bounded sensitivity rather than swapped in as the default.