### PR TITLE
Record the experiment that confirms the PEM Faraday form

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1347,6 +1347,18 @@ def create_variables(model, optmodel, indlog):
             # 69.4, so it is conservative against the reviewer's own PEM reference, and the whole
             # 20-100% span sits inside Buttler & Spliethoff's 55.6-72.3 kWh/kg range for PEMEL.
             #
+            # Measurement backs the form. Yodwong et al. 2020 (Energies 13:4792) tested a 50 cm2
+            # PEM cell at 1, 5 and 10 bar and fitted eta_F = a (i/A)^b + c with all three
+            # parameters free. The fit returned b = -1 and c = 1 at every pressure, which is
+            # 1 - i_x/i exactly, and reproduces their table to 1e-4. The exponent could have gone
+            # anywhere and went to -1, so constant crossover is what their data says.
+            #
+            # Their magnitude also says ours is the pessimistic end. |a| rises linearly with
+            # pressure and extrapolates to 21 A/m2 at the 30 bar this case runs at, against the
+            # 280 A/m2 assumed here. We charge PEM roughly thirteen times the crossover loss they
+            # measured, so the low-load penalty is an upper bound on theirs. It stays there
+            # because their cell is a bench unit and 30 bar is beyond the pressures they tested.
+            #
             # Worth recording: Astriani's own curve is monotone with no interior optimum, which
             # disagrees with Baumhof's alkaline curve and with Buttler & Spliethoff. Both curves
             # here have an interior optimum because both are built from the same physics. That


### PR DESCRIPTION
Comment only. No numbers change.

## What this records

The PEM half of the derived electrolyser curve uses `eta_F = 1 - i_x/i` for Faraday efficiency, on the reasoning that a solid membrane loses hydrogen by permeation at a rate set by the pressure difference and largely independent of current. Alkaline uses `f2 i^2/(f1 + i^2)` instead, because a porous diaphragm loses hydrogen in proportion to the gas produced.

That was an argument from physics. It now has an experiment behind it.

Yodwong et al. 2020 (Energies 13:4792) tested a 50 cm2 PEM cell at 1, 5 and 10 bar and fitted

    eta_F = a (i/A)^b + c

with **a, b and c all free**. The regression returned **b = -1 and c = 1 at every pressure**, which is `1 - i_x/i` exactly, and reproduces their own table to 1e-4. The exponent could have come back at anything and came back at -1 three times out of three.

## The magnitude says this file is on the pessimistic side

Their fitted crossover rises linearly with pressure:

| p (bar) | crossover current | as a share of the 28,000 A/m2 rating used here |
|---|---|---|
| 1 | 1.0 A/m2 | 0.004% |
| 5 | 3.7 A/m2 | 0.013% |
| 10 | 7.1 A/m2 | 0.026% |
| 30 (extrapolated) | 20.8 A/m2 | 0.074% |
| **this file** | **280 A/m2** | **1.0%** |

So PEM is charged roughly thirteen times the crossover loss they measured, even after extrapolating to the 30 bar the case runs at.

## Why it is left at 1 per cent

Their cell is a bench unit, 30 bar is past the pressures they tested, and crossover scales inversely with membrane thickness, which they do not report. Lowering `i_x` would shrink the low-load penalty on PEM, and PEM is the technology under test. The conservative direction is to leave it and say so.