### PR TITLE
Add a curve variant that isolates the PEM Faraday term

### DIFF
--- a/src/el1xr_opt/Modules/oM_InputData.py
+++ b/src/el1xr_opt/Modules/oM_InputData.py
@@ -1363,6 +1363,22 @@ def create_variables(model, optmodel, indlog):
             # disagrees with Baumhof's alkaline curve and with Buttler & Spliethoff. Both curves
             # here have an interior optimum because both are built from the same physics. That
             # disagreement belongs in the paper's text, not hidden inside a fit.
+            # Baseline alkaline, but PEM WITH its Faraday crossover term. This isolates one
+            # change, because 'ulleberg_conservative' moves both technologies at once and cannot
+            # say which of them did the work.
+            #
+            # It exists because the baseline 'ulleberg' PEM row above was generated before the PEM
+            # half was rebuilt, and so carries NO Faraday term at all: it assumes every electron
+            # makes hydrogen at every load. That is not physical, and Yodwong et al. 2020 measured
+            # the loss directly. Against the derived curve the baseline understates PEM's specific
+            # consumption by 24% at 5% load, 13% at 8% and 7% at 14%, which is exactly the deep
+            # turn-down range PEM is valued for. The multipliers here are the same PEM column as
+            # the conservative set, since both come from the same construction.
+            'ulleberg_pemfaraday':
+                ([0.2000, 0.2615, 0.3420, 0.4472, 0.5848, 0.7647, 1.0000],
+                 [1.0501, 0.9911, 0.9559, 0.9407, 0.9432, 0.9627, 1.0000],
+                 [0.0500, 0.0824, 0.1357, 0.2236, 0.3684, 0.6070, 1.0000],
+                 [2.7570, 1.8496, 1.3864, 1.1433, 1.0232, 0.9816, 1.0000]),
             'ulleberg_conservative':
                 ([0.2000, 0.2615, 0.3420, 0.4472, 0.5848, 0.7647, 1.0000],
                  [1.3162, 1.1341, 1.0326, 0.9807, 0.9625, 0.9700, 1.0000],


### PR DESCRIPTION
Additive. Nothing already run changes.

## The problem

The baseline `ulleberg` PEM column was generated before the PEM half was rebuilt, and it carries **no Faraday term at all**. It assumes every electron makes hydrogen at every load.

That is not physical, and it is not what the paper says. Yodwong et al. 2020 measured the crossover directly on a PEM cell at three pressures, and `analysis/electrolyser_curve.py` now models it. Reproducing the baseline row requires deleting the Faraday term from the derivation entirely — confirmed to 2e-4.

What the baseline understates:

| load | baseline | with crossover | understated by |
|---|---|---|---|
| 0.05 | 134.9 | 166.9 kWh/kg | **24%** |
| 0.08 | 99.4 | 112.0 | 13% |
| 0.14 | 78.5 | 83.9 | 7% |
| 0.22 | 66.8 | 69.2 | 4% |
| 1.00 | 60.5 | 60.5 | 0% |

That is exactly the deep turn-down range PEM is valued for, and PEM is the technology under test — so the baseline flatters it where it matters most.

**Figure 1(a) of the paper already draws the corrected curve.** So the figure, the manuscript text and the model currently disagree, and the model is the one that is wrong.

## Why a new variant rather than fixing the baseline

`ulleberg_conservative` already has the corrected PEM column, but it *also* swaps alkaline's Faraday parameters from Ulleberg to Sánchez. It moves both technologies at once, so it cannot say which one did the work.

`ulleberg_pemfaraday` is baseline alkaline plus corrected PEM. One change. It answers whether the baseline needs replacing, and at the cost of a single solve rather than a full campaign.

If the answer is that it matters, the baseline row gets replaced in a follow-up and the campaign runs again. If it does not, the completed campaign stands and the corrected curve is reported as a sensitivity.

## Verification

Both columns of the new entry reproduce `analysis/electrolyser_curve.py` to better than 5e-4. The baseline, the two balance-of-plant variants and the conservative set are untouched.